### PR TITLE
refactor: LQPW-2 List 리팩토링

### DIFF
--- a/src/components/base/BaseList.vue
+++ b/src/components/base/BaseList.vue
@@ -1,0 +1,164 @@
+<script setup>
+import { computed, ref } from 'vue';
+import Sentinel from '@/components/extra/Sentinel.vue'; // 경로 확인 필요
+
+const props = defineProps({
+  headers: {
+    type: Array,
+    required: true,
+  },
+  items: {
+    type: Array,
+    required: true,
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+  showCheckboxes: {
+    type: Boolean,
+    default: true,
+  },
+  checkedIds: {
+    type: Set,
+    default: () => new Set(),
+  },
+  currentPage: {
+    type: Number,
+    default: 1,
+  },
+  totalPage: {
+    type: Number,
+    default: 0,
+  },
+});
+
+const emit = defineEmits(['update:checkedIds', 'intersect', 'check-all']);
+
+const lastCheckedIndex = ref(null);
+
+const isAllChecked = computed(() => {
+  if (!props.items || props.items.length === 0) return false;
+  return props.items.every((item) => props.checkedIds.has(item.id));
+});
+
+function handleCheckAll(event) {
+  const newCheckedIds = new Set(props.checkedIds);
+  if (event.target.checked) {
+    props.items.forEach((item) => newCheckedIds.add(item.id));
+  } else {
+    props.items.forEach((item) => newCheckedIds.delete(item.id));
+  }
+  emit('update:checkedIds', newCheckedIds);
+}
+
+function handleCheckboxClick(event, index) {
+  const item = props.items[index];
+  const id = item.id;
+  const newCheckedIds = new Set(props.checkedIds);
+
+  if (event.shiftKey && lastCheckedIndex.value !== null) {
+    const start = Math.min(lastCheckedIndex.value, index);
+    const end = Math.max(lastCheckedIndex.value, index);
+    const rangeItems = props.items.slice(start, end + 1);
+    const clickedWasChecked = newCheckedIds.has(id);
+
+    rangeItems.forEach((v) => {
+      if (clickedWasChecked) {
+        newCheckedIds.delete(v.id);
+      } else {
+        newCheckedIds.add(v.id);
+      }
+    });
+  } else {
+    if (newCheckedIds.has(id)) {
+      newCheckedIds.delete(id);
+    } else {
+      newCheckedIds.add(id);
+    }
+  }
+
+  lastCheckedIndex.value = index;
+  emit('update:checkedIds', newCheckedIds);
+}
+
+function handleIntersect() {
+  if (!props.loading && props.currentPage < props.totalPage) {
+    emit('intersect');
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-1 flex-col overflow-x-auto overflow-y-hidden rounded-lg border-2 border-gray-200 bg-white outline outline-white/5 dark:border-gray-700 dark:bg-gray-950/50">
+    <!-- 고정 헤더 테이블 -->
+    <div class="flex min-w-[1300px] flex-1 flex-col overflow-y-hidden">
+      <div class="block h-14">
+        <table class="h-full w-full min-w-[1300px] table-fixed">
+          <thead class="bg-gray-100 dark:bg-gray-700">
+            <tr>
+              <th v-if="showCheckboxes" class="w-[2%] px-4 py-2 text-left">
+                <input type="checkbox" :checked="isAllChecked" @change="handleCheckAll" />
+              </th>
+              <th
+                v-for="header in headers"
+                :key="header.value"
+                :class="['px-4 py-2', header.align === 'right' ? 'text-right' : 'text-left', `w-[${header.width}]`]"
+              >
+                <slot :name="`header.${header.value}`" :header="header">
+                  {{ header.text }}
+                </slot>
+              </th>
+            </tr>
+          </thead>
+        </table>
+      </div>
+
+      <div>
+        <table class="w-full min-w-[1300px] table-fixed">
+            <slot name="fixed-body"></slot>
+        </table>
+      </div>
+
+      <div class="no-scrollbar min-h-0 flex-1 overflow-y-scroll">
+        <table class="w-full min-w-[1300px] table-fixed">
+          <tbody>
+            <tr
+              v-for="(item, index) in items"
+              :key="item.id"
+              class="border-b border-gray-200 dark:border-gray-700"
+            >
+              <td v-if="showCheckboxes" class="w-[2%] px-4 py-2">
+                <input
+                  type="checkbox"
+                  :checked="checkedIds.has(item.id)"
+                  @click="handleCheckboxClick($event, index)"
+                />
+              </td>
+              <td
+                v-for="header in headers"
+                :key="header.value"
+                :class="['px-4 py-2', header.align === 'right' ? 'text-right' : 'text-left', `w-[${header.width}]`]"
+              >
+                <slot :name="`item.${header.value}`" :item="item" :index="index">
+                  {{ item[header.value] }}
+                </slot>
+              </td>
+            </tr>
+            <Sentinel v-if="currentPage < totalPage" :onIntersect="handleIntersect" />
+          </tbody>
+        </table>
+         <div v-if="loading" class="flex justify-center items-center p-4">
+            <p>로딩 중...</p>
+          </div>
+          <div v-if="!loading && items.length === 0" class="flex justify-center items-center p-4">
+            <p>데이터가 없습니다.</p>
+          </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* 필요한 경우 스타일 추가 */
+</style>

--- a/src/components/extra/List.vue
+++ b/src/components/extra/List.vue
@@ -2,12 +2,18 @@
 import { ref, watch, onUnmounted, computed, onMounted, nextTick } from 'vue';
 import Dropdown from './Dropdown.vue';
 import { authFetch } from '../../utils/authFetch';
-import Sentinel from './Sentinel.vue';
 import DateSearch from './DateSearch.vue';
 import EditModal from './EditModal.vue';
 import { useTypeStore } from '@/stores/typeStore';
 import { getRoleFromLocalStorage } from '@/utils/token';
 import { groupOptions, groupNameToEnum, groupIdToName, loadGroupOptions } from '@/stores/group';
+import BaseList from '@/components/base/BaseList.vue';
+import UserInput from './UserInput.vue';
+import Searchbar from './Searchbar.vue';
+import { useToast } from 'vue-toastification';
+import JSZip from 'jszip';
+import { saveAs } from 'file-saver';
+
 const selectedGroup = ref('');
 const roles = ref(getRoleFromLocalStorage());
 
@@ -29,11 +35,10 @@ worker.onmessage = (e) => {
 
 const isLoading = ref(false);
 const selectedCompany = ref('');
-const selectedDate = ref('');
 const fileLists = ref([]);
 const totalPage = ref(0);
 const currentPage = ref(1);
-const isPdfConverting = ref(false); // PDF URL 생성 로딩 상태
+const isPdfConverting = ref(false);
 const start_at = ref('');
 const end_at = ref('');
 const companyOptions = ['백성운수', '평택여객', '파란전기'];
@@ -44,71 +49,21 @@ const companyNameToEnum = {
 };
 const searchbar = ref('');
 const searchbarOption = ref('');
-
-const checkedIds = ref(new Set()); // ✅ 체크된 파일의 id 저장
-const lastCheckedIndex = ref(null);
+const checkedIds = ref(new Set());
 const hasChecked = computed(() => checkedIds.value.size > 0);
-const isAllChecked = computed(() => {
-  return fileLists.value.length > 0 && fileLists.value.every((v) => checkedIds.value.has(v.id));
-});
-
-function handleCheckAll(event) {
-  if (event.target.checked) {
-    // 현재 화면에 보이는 모든 전표의 id를 체크!
-    fileLists.value.forEach((v) => checkedIds.value.add(v.id));
-  } else {
-    // 현재 화면에 보이는 모든 전표의 id를 해제!
-    fileLists.value.forEach((v) => checkedIds.value.delete(v.id));
-  }
-  checkedIds.value = new Set(checkedIds.value); // 반응성 유도
-}
-
-const handleCheckboxClick = (event, index) => {
-  const file = fileLists.value[index];
-  const id = file.id;
-
-  if (event.shiftKey && lastCheckedIndex.value !== null) {
-    const start = Math.min(lastCheckedIndex.value, index);
-    const end = Math.max(lastCheckedIndex.value, index);
-
-    const rangeFiles = fileLists.value.slice(start, end + 1);
-
-    const clickedWasChecked = checkedIds.value.has(id);
-
-    rangeFiles.forEach((f) => {
-      if (clickedWasChecked) {
-        checkedIds.value.delete(f.id); // 전체 해제
-      } else {
-        checkedIds.value.add(f.id); // 전체 체크
-      }
-    });
-
-    // ✅ 기준점 갱신! ← 이게 핵심
-    lastCheckedIndex.value = index;
-  } else {
-    // 일반 클릭 (토글)
-    if (checkedIds.value.has(id)) {
-      checkedIds.value.delete(id);
-    } else {
-      checkedIds.value.add(id);
-    }
-
-    // 기준점 갱신
-    lastCheckedIndex.value = index;
-  }
-};
-
-import UserInput from './UserInput.vue';
-import Searchbar from './Searchbar.vue';
-import { useToast } from 'vue-toastification';
-import { files } from 'jszip';
-import { file } from 'jszip';
 
 const fileUrl = `${import.meta.env.VITE_FILE_API_URL}`;
 const toast = useToast();
 const isEditModalOpen = ref(false);
 const editTargetFile = ref(null);
 const lockFilter = ref(false);
+
+const headers = ref([
+    { text: '날짜', value: 'withdrawn_at', width: '8%' },
+    { text: '설명', value: 'name', width: '60%' },
+    { text: '첨부파일', value: 'file_name', width: '25%' },
+    { text: '', value: 'actions', width: '5%' },
+]);
 
 function openEditModal(file) {
   editTargetFile.value = file;
@@ -220,62 +175,45 @@ async function editFile(payload) {
   }
 }
 
-// 날짜 포맷 함수
 function formatDate(dateStr) {
-  // 입력값이 "20250320" 형식일 경우 처리
-  const year = dateStr.substring(0, 4); // "2025"
-  const month = dateStr.substring(4, 6); // "03"
-  const day = dateStr.substring(6, 8); // "20"
-
-  // YYYY/MM/DD 형식으로 반환
+  const year = dateStr.substring(0, 4);
+  const month = dateStr.substring(4, 6);
+  const day = dateStr.substring(6, 8);
   return `${year}/${month}/${day}`;
 }
 
-// 금액 포맷 함수 (세 자리 콤마 추가)
-function formatPrice(price) {
-  return price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-}
-
-// *** 미리보기 위치 계산 및 조정 함수 ***
 function handlePreviewPosition(event) {
-  const container = event.currentTarget; // 이벤트가 부착된 요소 (div.group.relative.inline-block)
-  const preview = container.querySelector('.pdf-preview'); // 미리보기 div (클래스 추가 필요)
+  const container = event.currentTarget;
+  const preview = container.querySelector('.pdf-preview');
   if (!preview) return;
 
-  const containerRect = container.getBoundingClientRect(); // 컨테이너의 뷰포트 내 위치/크기
-  const previewHeight = preview.offsetHeight || 600; // 미리보기 높이 (h-80 = 20rem = 320px), 실제 측정값 사용 권장
-  const viewportHeight = window.innerHeight; // 뷰포트 높이
-  const spaceBelow = viewportHeight - containerRect.bottom; // 요소 아래 남은 공간
-  const spaceAbove = containerRect.top; // 요소 위 남은 공간 (뷰포트 상단 기준)
+  const containerRect = container.getBoundingClientRect();
+  const previewHeight = preview.offsetHeight || 600;
+  const viewportHeight = window.innerHeight;
+  const spaceBelow = viewportHeight - containerRect.bottom;
+  const spaceAbove = containerRect.top;
 
-  // 기본값: 아래로 표시
-  preview.classList.remove('bottom-full', 'mb-2'); // '위로' 스타일 제거
-  preview.classList.add('top-full', 'mt-2'); // '아래로' 스타일 추가 (기본)
+  preview.classList.remove('bottom-full', 'mb-2');
+  preview.classList.add('top-full', 'mt-2');
 
-  // 아래 공간이 부족하고 위 공간이 충분하면 위로 표시
   if (spaceBelow < previewHeight && spaceAbove > previewHeight) {
-    preview.classList.remove('top-full', 'mt-2'); // '아래로' 스타일 제거
-    preview.classList.add('bottom-full', 'mb-2'); // '위로' 스타일 추가 (mb-2는 위쪽 여백)
+    preview.classList.remove('top-full', 'mt-2');
+    preview.classList.add('bottom-full', 'mb-2');
   }
-  // 다른 경우는 기본값(아래로 표시) 유지
 }
 
-// *** 마우스 벗어날 때 스타일 초기화 함수 (선택적이지만 권장) ***
 function resetPreviewPosition(event) {
   const container = event.currentTarget;
   const preview = container.querySelector('.pdf-preview');
   if (!preview) return;
 
-  // 기본 '아래로' 스타일로 복원
   preview.classList.remove('bottom-full', 'mb-2');
   preview.classList.add('top-full', 'mt-2');
 }
 
 function handleIntersect() {
-  if (!isLoading.value && !isPdfConverting.value && currentPage.value < totalPage.value) {
     currentPage.value++;
     fetchFiles();
-  }
 }
 
 function search() {
@@ -286,18 +224,16 @@ function downloadCheckedFiles() {
   const files = [...checkedIds.value].reduce((acc, id) => {
     const file = fileLists.value.find((v) => v.id === id);
     if (file.file_data) {
-      acc.push(file); // => 파일들을 하나하나 분해해서 acc에 추가
+      acc.push(file);
     }
     return acc;
   }, []);
 
   downloadAllFiles(files);
 
-  checkedIds.value.clear(); // 다운로드 후 체크박스 초기화
-  lastCheckedIndex.value = null; // 기준점 초기화
+  checkedIds.value.clear();
 }
-import JSZip from 'jszip';
-import { saveAs } from 'file-saver';
+
 function downloadAllFiles(files, id = '') {
   const zip = new JSZip();
   const nameCount = {};
@@ -310,7 +246,6 @@ function downloadAllFiles(files, id = '') {
       nameCount[name]++;
       const extIdx = name.lastIndexOf('.');
       if (extIdx > 0) {
-        // 확장자 앞에 (1), (2) 등 추가
         name = name.slice(0, extIdx) + `(${nameCount[name]})` + name.slice(extIdx);
       } else {
         name = name + `(${nameCount[name]})`;
@@ -328,14 +263,8 @@ function downloadAllFiles(files, id = '') {
   });
 }
 
-// 메모리 누수 방지용 URL 저장소
-const objectUrls = new Map();
-
-// 컴포넌트가 사라질 때 URL 정리
 onUnmounted(() => {
-  for (const url of objectUrls.values()) {
-    URL.revokeObjectURL(url);
-  }
+  worker.terminate();
 });
 
 watch(selectedCompany, async (newCompany) => {
@@ -357,7 +286,6 @@ watch([selectedCompany, start_at, end_at, lockFilter, selectedGroup], async () =
   <div class="bg-testPink flex h-full w-full flex-col p-8">
     <div class="grid grid-cols-2">
       <div class="col-span-1 flex gap-1">
-        <!-- 회사 선택 -->
         <div class="max-w-30">
           <Dropdown
             @select="(select) => (selectedCompany = select)"
@@ -366,7 +294,6 @@ watch([selectedCompany, start_at, end_at, lockFilter, selectedGroup], async () =
           />
         </div>
 
-        <!-- 그룹 선택 -->
         <div class="max-w-40" v-show="selectedCompany">
           <Dropdown
             v-model="selectedGroup"
@@ -380,7 +307,6 @@ watch([selectedCompany, start_at, end_at, lockFilter, selectedGroup], async () =
           />
         </div>
 
-        <!-- 삭제 버튼 -->
         <div
           class="flex h-9 max-w-35 items-center justify-center rounded-sm border border-gray-300 text-sm font-semibold hover:bg-red-500 hover:text-white"
           v-show="hasChecked"
@@ -415,186 +341,140 @@ watch([selectedCompany, start_at, end_at, lockFilter, selectedGroup], async () =
             }
           "
         />
-        <!-- <div
-          class="ml-2 h-9 w-9 cursor-pointer rounded-sm hover:bg-black hover:text-white"
-          @click="search"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke-width="1.5"
-            stroke="currentColor"
-            class="size-9"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
-            />
-          </svg>
-        </div> -->
       </div>
     </div>
-    <div
-      class="flex flex-1 flex-col overflow-x-auto overflow-y-hidden rounded-lg border-2 border-gray-200 bg-white outline outline-white/5 dark:border-gray-700 dark:bg-gray-950/50"
+
+    <BaseList
+        :headers="headers"
+        :items="fileLists"
+        :loading="isLoading || isPdfConverting"
+        :checkedIds="checkedIds"
+        @update:checkedIds="checkedIds = $event"
+        :currentPage="currentPage"
+        :totalPage="totalPage"
+        @intersect="handleIntersect"
     >
-      <!-- 고정 헤더 테이블 -->
-      <div class="flex min-w-[1300px] flex-1 flex-col overflow-y-hidden">
-        <div class="block h-10 w-full">
-          <table class="h-10 w-full min-w-[1300px] table-fixed">
-            <thead class="bg-gray-100 dark:bg-gray-700">
-              <tr>
-                <th class="w-[2%] px-4 py-2 text-left">
-                  <input
-                    type="checkbox"
-                    id="check-all"
-                    :checked="isAllChecked"
-                    @change="handleCheckAll"
-                  />
-                </th>
-                <th class="w-[8%] px-4 py-2 text-left">날짜</th>
-                <th class="w-[60%] truncate px-4 py-2 text-left">설명</th>
-                <th class="w-[25%] px-4 py-2 text-left">
-                  <div class="flex justify-between">
-                    <div class="flex items-center justify-center">첨부파일</div>
-                    <div
-                      class="ml-2 flex h-6 w-20 items-center justify-center rounded-sm border border-gray-300 text-sm font-semibold hover:bg-blue-500 hover:text-white"
-                      v-show="hasChecked"
-                    >
-                      <input
+        <template #fixed-body>
+            <UserInput
+                v-show="selectedGroup"
+                :selectedCompany="selectedCompany"
+                @createFiles="addCreatedFiles"
+                :selectedGroupId="selectedGroup"
+            />
+        </template>
+
+        <template #header.file_name="{ header }">
+            <div class="flex justify-between">
+                <div class="flex items-center justify-center">{{ header.text }}</div>
+                <div
+                    class="ml-2 flex h-6 w-20 items-center justify-center rounded-sm border border-gray-300 text-sm font-semibold hover:bg-blue-500 hover:text-white"
+                    v-show="hasChecked"
+                >
+                    <input
                         class="h-full w-full cursor-pointer content-center rounded-sm text-sm"
                         type="button"
                         value="일괄 저장"
                         @click="downloadCheckedFiles"
-                      />
-                    </div>
-                    <div>
-                      <input id="lock-filter" v-show="false" type="checkbox" v-model="lockFilter" />
-                      <label
+                    />
+                </div>
+                <div>
+                    <input id="lock-filter" v-show="false" type="checkbox" v-model="lockFilter" />
+                    <label
                         v-if="roles.includes('ADMIN') && selectedCompany"
                         for="lock-filter"
                         class="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border border-gray-300 hover:bg-gray-200"
-                      >
+                    >
                         <svg
-                          v-if="lockFilter"
-                          xmlns="http://www.w3.org/2000/svg"
-                          class="h-4 w-4 text-gray-800"
-                          fill="currentColor"
-                          viewBox="0 0 24 24"
+                            v-if="lockFilter"
+                            xmlns="http://www.w3.org/2000/svg"
+                            class="h-4 w-4 text-gray-800"
+                            fill="currentColor"
+                            viewBox="0 0 24 24"
                         >
-                          <path
-                            d="M12 17a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm6-6h-1V9a5 5 0 0 0-10 0v2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2zm-3 0H9V9a3 3 0 1 1 6 0v2z"
-                          />
+                            <path
+                                d="M12 17a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm6-6h-1V9a5 5 0 0 0-10 0v2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2zm-3 0H9V9a3 3 0 1 1 6 0v2z"
+                            />
                         </svg>
                         <svg
-                          v-else
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke-width="1.5"
-                          stroke="currentColor"
-                          class="size-3"
+                            v-else
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke-width="1.5"
+                            stroke="currentColor"
+                            class="size-3"
                         >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            d="M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
-                          />
+                            <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                d="M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
+                            />
                         </svg>
-                      </label>
-                    </div>
-                  </div>
-                </th>
-                <th class="w-[5%] px-4 py-2 text-left"></th>
-              </tr>
-            </thead>
-          </table>
-        </div>
+                    </label>
+                </div>
+            </div>
+        </template>
 
-        <UserInput
-          v-show="selectedGroup"
-          :selectedCompany="selectedCompany"
-          @createFiles="addCreatedFiles"
-          :selectedGroupId="selectedGroup"
-        />
+        <template #item.withdrawn_at="{ item }">
+            {{ formatDate(item.withdrawn_at) }}
+        </template>
 
-        <div class="no-scrollbar min-h-0 flex-1 overflow-y-scroll">
-          <table class="w-full min-w-[1300px] table-fixed">
-            <tbody>
-              <!-- 반복 행 예시 -->
-              <tr
-                v-for="(file, index) in fileLists"
-                :key="file.id"
-                class="files w-full border-b border-gray-200 dark:border-gray-700"
-              >
-                <td class="w-[2%] px-4 py-2">
-                  <input
-                    type="checkbox"
-                    class="row-check"
-                    :checked="checkedIds.has(file.id)"
-                    @click="handleCheckboxClick($event, index)"
-                  />
-                </td>
-                <td class="w-[8%] px-4 py-2">
-                  {{ formatDate(file.withdrawn_at) }}
-                </td>
-                <td class="flex w-[60%] truncate px-4 py-2">
-                  {{ file.name }}
-                  <svg
-                    v-if="file.lock"
+        <template #item.name="{ item }">
+            <div class="flex items-center">
+                {{ item.name }}
+                <svg
+                    v-if="item.lock"
                     xmlns="http://www.w3.org/2000/svg"
                     class="ml-1 h-4 w-4 text-gray-800"
                     fill="currentColor"
                     viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 17a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm6-6h-1V9a5 5 0 0 0-10 0v2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2zm-3 0H9V9a3 3 0 1 1 6 0v2z"
-                    />
-                  </svg>
-                </td>
-                <td
-                  class="group relative w-[25%] px-4 py-2 text-ellipsis whitespace-nowrap"
-                  @mouseenter="handlePreviewPosition"
-                  @mouseleave="resetPreviewPosition"
                 >
-                  <div class="group relative inline-block w-full">
+                    <path
+                        d="M12 17a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm6-6h-1V9a5 5 0 0 0-10 0v2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2zm-3 0H9V9a3 3 0 1 1 6 0v2z"
+                    />
+                </svg>
+            </div>
+        </template>
+
+        <template #item.file_name="{ item }">
+            <div
+                class="group relative w-full text-ellipsis whitespace-nowrap"
+                @mouseenter="handlePreviewPosition"
+                @mouseleave="resetPreviewPosition"
+            >
+                <div class="group relative inline-block w-full">
                     <div class="w-full overflow-hidden text-ellipsis whitespace-nowrap">
-                      <a
-                        :href="`data:application/pdf;base64,${file.file_data}`"
-                        :download="file.file_name"
+                        <a
+                        :href="`data:application/pdf;base64,${item.file_data}`"
+                        :download="item.file_name"
                         class="text-blue-500 hover:text-blue-600"
-                      >
-                        {{ file.file_name }}
-                      </a>
+                        >
+                        {{ item.file_name }}
+                        </a>
                     </div>
                     <div
-                      class="pdf-preview absolute top-full left-0 z-20 mt-2 hidden h-80 w-64 border border-gray-300 bg-white p-2 shadow-lg group-hover:block"
+                        class="pdf-preview absolute top-full left-0 z-20 mt-2 hidden h-80 w-64 border border-gray-300 bg-white p-2 shadow-lg group-hover:block"
                     >
-                      <embed
-                        v-if="file.pdf_url"
-                        :src="file.pdf_url"
-                        type="application/pdf"
-                        class="h-full w-full"
-                      />
+                        <embed
+                            v-if="item.pdf_url"
+                            :src="item.pdf_url"
+                            type="application/pdf"
+                            class="h-full w-full"
+                        />
                     </div>
-                  </div>
-                </td>
-                <td class="mr-2 h-full w-[5%] py-2 text-base">
-                  <input
-                    type="button"
-                    value="수정"
-                    @click="openEditModal(file)"
-                    class="h-6 w-14 cursor-pointer rounded-sm border border-gray-300 bg-white pr-1.5 pl-1.5 text-sm hover:bg-black hover:text-white"
-                  />
-                </td>
-              </tr>
-              <Sentinel v-if="currentPage < totalPage" :onIntersect="handleIntersect" />
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
+                </div>
+            </div>
+        </template>
+
+        <template #item.actions="{ item }">
+            <input
+                type="button"
+                value="수정"
+                @click="openEditModal(item)"
+                class="h-6 w-14 cursor-pointer rounded-sm border border-gray-300 bg-white pr-1.5 pl-1.5 text-sm hover:bg-black hover:text-white"
+            />
+        </template>
+    </BaseList>
 
     <EditModal
       :visible="isEditModalOpen"

--- a/src/components/extra/UserInput.vue
+++ b/src/components/extra/UserInput.vue
@@ -1,83 +1,77 @@
 <template>
-  <div v-if="selectedCompany" class="block border-b border-gray-200 bg-gray-50">
-    <table class="w-full min-w-[1300px] table-fixed">
-      <thead class="">
-        <tr class="w-full">
-          <td class="w-[2%] px-4 py-2 text-left"></td>
-          <td class="w-[8%] px-4 py-2">
-            <Flatpickr
-              class="w-full rounded-sm border border-gray-300"
-              v-model="date"
-              :config="config"
-              placeholder="날짜를 선택하세요"
+  <tr v-if="selectedCompany" class="border-b border-gray-200 bg-gray-50">
+    <td class="w-[2%] px-4 py-2 text-left"></td>
+    <td class="w-[8%] px-4 py-2">
+      <Flatpickr
+        class="w-full rounded-sm border border-gray-300"
+        v-model="date"
+        :config="config"
+        placeholder="날짜를 선택하세요"
+      />
+    </td>
+    <td class="w-[60%] truncate px-4 py-2 text-left">
+      <input
+        class="w-full rounded-sm border border-gray-300 pl-1"
+        type="text"
+        placeholder="설명을 입력하세요"
+        v-model="description"
+      />
+    </td>
+    <td class="w-[25%] px-4 py-2 text-left">
+      <div class="flex gap-1.5">
+        <input
+          :class="roles.includes('ADMIN') ? 'col-span-3' : 'col-span-4'"
+          ref="fileInput"
+          class="flex w-full rounded-sm border border-gray-300 pl-1"
+          type="file"
+          multiple
+          accept=".pdf, .jpg, .jpeg, .png"
+          @change="handleFileChange"
+        />
+        <input id="lock" v-show="false" type="checkbox" v-model="isLocked" />
+        <label
+          v-show="roles.includes('ADMIN')"
+          for="lock"
+          class="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border border-gray-300 hover:bg-gray-200"
+        >
+          <svg
+            v-if="isLocked"
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-4 w-4 text-gray-800"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 17a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm6-6h-1V9a5 5 0 0 0-10 0v2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2zm-3 0H9V9a3 3 0 1 1 6 0v2z"
             />
-          </td>
-          <td class="w-[60%] truncate px-4 py-2 text-left">
-            <input
-              class="w-full rounded-sm border border-gray-300 pl-1"
-              type="text"
-              placeholder="설명을 입력하세요"
-              v-model="description"
+          </svg>
+          <svg
+            v-else
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="size-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
             />
-          </td>
-          <td class="w-[25%] px-4 py-2 text-left">
-            <div class="flex gap-1.5">
-              <input
-                :class="roles.includes('ADMIN') ? 'col-span-3' : 'col-span-4'"
-                ref="fileInput"
-                class="flex w-full rounded-sm border border-gray-300 pl-1"
-                type="file"
-                multiple
-                accept=".pdf, .jpg, .jpeg, .png"
-                @change="handleFileChange"
-              />
-              <input id="lock" v-show="false" type="checkbox" v-model="isLocked" />
-              <label
-                v-show="roles.includes('ADMIN')"
-                for="lock"
-                class="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border border-gray-300 hover:bg-gray-200"
-              >
-                <svg
-                  v-if="isLocked"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="h-4 w-4 text-gray-800"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 17a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm6-6h-1V9a5 5 0 0 0-10 0v2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2zm-3 0H9V9a3 3 0 1 1 6 0v2z"
-                  />
-                </svg>
-                <svg
-                  v-else
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke-width="1.5"
-                  stroke="currentColor"
-                  class="size-3"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
-                  />
-                </svg>
-              </label>
-            </div>
-          </td>
-          <td class="w-[5%]">
-            <button
-              class="col-span-1 w-15 cursor-pointer rounded-md border border-gray-300 p-0 px-1 py-0.5 text-sm hover:bg-black hover:text-white"
-              @click="saveFile"
-            >
-              입력
-            </button>
-          </td>
-        </tr>
-      </thead>
-    </table>
-  </div>
+          </svg>
+        </label>
+      </div>
+    </td>
+    <td class="w-[5%] px-4 py-2">
+      <input
+        type="button"
+        value="입력"
+        @click="saveFile"
+        class="h-6 w-14 cursor-pointer rounded-sm border border-gray-300 bg-white pr-1.5 pl-1.5 text-sm hover:bg-black hover:text-white"
+      />
+    </td>
+  </tr>
 </template>
 
 <script setup>


### PR DESCRIPTION
  리팩토링 이전의 문제점

  처음 프로젝트를 분석했을 때, 다음과 같은 주요 문제점들이 있었습니다.


   1. 심각한 코드 중복: extra/List.vue와 lists/List.vue는 이름만 다를 뿐, 내부의 코드(템플릿
      구조, 스크립트 로직)가 거의 90% 이상 동일했습니다. 이는 다음과 같은 문제를 야기합니다.
       * 유지보수 비용 증가: 작은 기능 하나를 수정하거나 버그를 고칠 때, 양쪽 파일을 모두
         찾아 동일하게 수정해야만 했습니다. 하나라도 놓치면 버그가 발생합니다.
       * 실수 유발: 동일한 코드를 여러 번 수정하다 보면 실수가 발생할 확률이 높아집니다.


   2. 컴포넌트의 과도한 책임 (God Component): 하나의 List.vue 컴포넌트가 너무 많은 일을 하고
      있었습니다.
       * 서버에서 데이터 가져오기 (API 호출)
       * 데이터 상태 관리 (로딩, 페이지네이션, 체크박스 선택, 정렬 등)
       * 복잡한 UI 렌더링 (테이블, 헤더, 행, 셀)
       * 사용자 이벤트 처리 (버튼 클릭, 무한 스크롤)
       * 이렇게 하나의 컴포넌트가 비대해지면 코드를 이해하기 어렵고, 특정 기능을 수정할 때
         다른 기능에 영향을 줄 위험(사이드 이펙트)이 커집니다.


   3. 낮은 재사용성: 리스트 UI와 데이터 로직이 강하게 결합되어 있어, 이 리스트 컴포넌트를 다른       
       종류의 데이터를 보여주는 곳에 재사용하는 것이 거의 불가능했습니다. 새로운 리스트가
      필요할 때마다 기존 코드를 복사-붙여넣기 해야 하는 구조였습니다.

  리팩토링 목표 및 해결 과정


  이러한 문제들을 해결하기 위해 컴포넌트 분리 및 재사용성 극대화를 목표로 잡고 다음과 같은
  단계로 리팩토링을 진행했습니다.

  1단계: 공통 UI 및 로직 추출 → BaseList.vue 생성


   * 작업 내용:
      두 List.vue 파일에 중복되어 있던 테이블(<table>) 구조, 헤더, 행 렌더링 로직,
  체크박스 전체 선택 및 Shift 키를 이용한 다중 선택 로직, 무한 스크롤 감지
  기능(Sentinel)을 모두 추출하여 src/components/base/BaseList.vue라는 새로운 범용
  컴포넌트를 만들었습니다.


   * 이유 (Why):
      "Don't Repeat Yourself" (DRY, 반복하지 마라) 원칙을 적용한 것입니다. 공통 코드를 한
  곳으로 모아 중앙에서 관리함으로써, 앞으로 리스트의 디자인이나 기능에 변경이 필요할 때
  BaseList.vue 파일 하나만 수정하면 프로젝트의 모든 리스트에 일관되게 적용할 수 있습니다.
  이는 유지보수 효율을 극대화합니다.


  2단계: props와 slots를 활용한 컴포넌트 일반화


   * 작업 내용:
       * Props: BaseList.vue가 어떤 데이터를 표시할지, 헤더는 어떻게 구성될지, 로딩 상태는
         어떠한지를 부모 컴포넌트로부터 전달받도록 items, headers, loading 등의 props를
         정의했습니다.
       * Slots: 리스트의 특정 열(column)이나 특정 부분의 HTML 구조가 부모 컴포넌트마다 달라질
          수 있는 유연성을 제공하기 위해 slot을 적극적으로 활용했습니다. 예를 들어,
         extra/List.vue의 '첨부파일' 헤더와 lists/List.vue의 '첨부파일' 헤더는 버튼 구성이
         다릅니다. slot을 사용하면 BaseList.vue는 "이 자리에 무언가 들어온다"는 사실만 알고,
         구체적인 내용은 부모가 채워 넣도록 할 수 있습니다.


   * 이유 (Why):
      이는 "관심사의 분리(Separation of Concerns)" 원칙을 따른 것입니다. BaseList.vue는
  "어떻게 보여줄 것인가"(UI)에만 집중하고, 부모 컴포넌트(extra/List.vue 등)는 "무엇을
  보여줄 것인가"(Data)에만 집중하게 됩니다. 이로써 각 컴포넌트의 책임이 명확해지고 코드가
  훨씬 단순하고 예측 가능해집니다.

  3단계: 상단 고정 및 정렬 문제 해결


   * 작업 내용:
       * UserInput 컴포넌트가 리스트와 함께 스크롤되는 문제를 해결하기 위해, BaseList.vue에
         스크롤 영역과 분리된 fixed-body라는 새로운 slot을 추가했습니다.
       * UserInput.vue의 최상위 태그를 <div>에서 테이블 행인 <tr>로 변경하고, 각 입력 필드를
         테이블 셀(<td>)로 감쌌습니다. 또한, 리스트의 컬럼과 정렬을 맞추기 위해 너비와 패딩
         스타일 클래스를 동일하게 적용했습니다.


   * 이유 (Why):
      사용자 경험(UX)과 시각적 일관성을 개선하기 위함입니다. 데이터 입력창은 사용자가
  스크롤하더라도 항상 볼 수 있도록 상단에 고정되는 것이 편리합니다. 또한, 입력 필드와 아래
  리스트의 컬럼이 정확히 일직선으로 정렬되어야 사용자가 안정감과 전문성을 느끼게 됩니다.
  <table>의 렌더링 특성을 활용하여 이 문제를 구조적으로 해결했습니다.

  리팩토링 결과 및 기대효과

  이번 리팩토링을 통해 다음과 같은 긍정적인 효과를 얻었습니다.


   * 유지보수성 향상: 중복 코드가 제거되어 이제 리스트 관련 수정은 BaseList.vue 한 곳에서
     처리하면 됩니다.
   * 재사용성 극대화: 앞으로 새로운 데이터 리스트가 필요할 경우, BaseList.vue를 가져다 쓰고
     필요한 데이터(props)와 커스텀 슬롯(slots)만 채워 넣으면 되므로 개발 속도가 매우
     빨라집니다.
   * 코드 가독성 증가: 각 컴포넌트의 코드가 짧아지고 책임이 명확해져, 다른 개발자가 코드를
     이해하고 수정하기 훨씬 쉬워졌습니다.
   * UI 일관성 확보: 프로젝트 내 모든 리스트가 동일한 BaseList를 사용하므로 일관된 사용자
     경험을 제공합니다.