### PR TITLE
feat: 전자결재 납부 업무 처리 흐름 개선

### DIFF
--- a/src/components/approval/ApprovalMain.vue
+++ b/src/components/approval/ApprovalMain.vue
@@ -49,6 +49,23 @@
           결재함
         </button>
         <button
+          @click="activeTab = 'payment-tasks'"
+          :class="[
+            'w-full flex items-center justify-between px-3 py-2.5 text-sm font-medium rounded-md transition-colors text-left',
+            activeTab === 'payment-tasks'
+              ? 'bg-blue-100 text-blue-700'
+              : 'text-gray-700 hover:bg-gray-200'
+          ]"
+        >
+          <span>납부 업무</span>
+          <span v-if="paymentTaskSummary.today_count > 0" class="ml-1 rounded-full bg-red-500 px-2 py-0.5 text-xs text-white">
+            오늘 {{ paymentTaskSummary.today_count }}
+          </span>
+          <span v-else-if="paymentTaskSummary.confirmation_count > 0" class="ml-1 rounded-full bg-indigo-500 px-2 py-0.5 text-xs text-white">
+            확인 {{ paymentTaskSummary.confirmation_count }}
+          </span>
+        </button>
+        <button
           @click="activeTab = 'search-all'"
           v-if="userStore.isAdmin"
           :class="[
@@ -104,6 +121,10 @@
           <CompletedApprovalList @view-detail="handleViewDetail" />
         </div>
 
+        <div v-if="activeTab === 'payment-tasks'">
+          <PaymentTaskList @summary-changed="handlePaymentTaskSummary" />
+        </div>
+
         <!-- 전체 검색 -->
         <div v-if="activeTab === 'search-all'">
           <AllApprovalSearch @view-detail="handleViewDetail" />
@@ -156,6 +177,8 @@ import CompletedApprovalList from './CompletedApprovalList.vue';
 import AllApprovalSearch from './AllApprovalSearch.vue';
 import TemplateManagement from './TemplateManagement.vue';
 import FavoriteGroupManagement from './FavoriteGroupManagement.vue';
+import PaymentTaskList from './PaymentTaskList.vue';
+import { paymentTaskApi } from '@/utils/approvalApi';
 
 const router = useRouter();
 const userStore = useUserStore();
@@ -167,6 +190,7 @@ const activeTab = ref('my-requests');
 const showDetailModal = ref(false);
 const selectedApproval = ref(null);
 const editRequestId = ref(null);
+const paymentTaskSummary = ref({ today_count: 0, confirmation_count: 0 });
 
 // 새 결재 생성 탭으로 이동
 const goToCreateApproval = () => {
@@ -197,6 +221,7 @@ onMounted(async () => {
   try {
     await userStore.fetchCurrentUser();
     await approvalStore.fetchPendingApprovals();
+    await refreshPaymentTaskSummary();
     
     // 웹소켓 연결 (결재 알림용)
     approvalNotificationStore.connectWebSocket();
@@ -205,8 +230,24 @@ onMounted(async () => {
   }
 });
 
+const refreshPaymentTaskSummary = async () => {
+  try {
+    paymentTaskSummary.value = await paymentTaskApi.getSummary();
+  } catch (error) {
+    console.error('납부 업무 요약 조회 오류:', error);
+  }
+};
+
+const handlePaymentTaskSummary = (summary) => {
+  paymentTaskSummary.value = summary;
+};
+
 // 새 결재 요청 생성 완료 핸들러
-const handleRequestCreated = () => {
+const handleRequestCreated = (createdItem) => {
+  if (createdItem?.assignee_id && !createdItem?.document_number) {
+    activeTab.value = 'payment-tasks';
+    return;
+  }
   approvalStore.fetchMyApprovalRequests();
   activeTab.value = 'my-requests';
 };

--- a/src/components/approval/CreateApprovalPage.vue
+++ b/src/components/approval/CreateApprovalPage.vue
@@ -145,7 +145,7 @@
               </label>
               <label class="block text-sm font-medium text-gray-700">
                 요청 금액
-                <input v-model.number="paymentRequest.amount" min="0" type="number" placeholder="0" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+                <input :value="formatAmountInput(paymentRequest.amount)" inputmode="numeric" type="text" placeholder="금액을 입력하세요" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" @input="updateAmountInput($event, value => (paymentRequest.amount = value))" />
               </label>
               <label class="block text-sm font-medium text-gray-700">
                 납부 기한
@@ -805,6 +805,38 @@ const getFileIcon = (fileName) => {
 
 const formatFileSize = (bytes) => {
   return approvalUtils.formatFileSize(bytes);
+};
+
+const formatAmountInput = (value) => {
+  if (value === null || value === undefined || value === '') return '';
+  return Number(value).toLocaleString('ko-KR');
+};
+
+const parseAmountInput = (value) => {
+  const digits = String(value).replace(/[^0-9]/g, '');
+  return digits ? Number(digits) : '';
+};
+
+const updateAmountInput = (event, updateValue) => {
+  const input = event.target;
+  const digitPosition = input.value.slice(0, input.selectionStart ?? input.value.length).replace(/[^0-9]/g, '').length;
+  const amount = parseAmountInput(input.value);
+  updateValue(amount);
+
+  nextTick(() => {
+    const formatted = formatAmountInput(amount);
+    let digitsSeen = 0;
+    let caretPosition = formatted.length;
+    for (let index = 0; index < formatted.length; index += 1) {
+      if (/\d/.test(formatted[index])) digitsSeen += 1;
+      if (digitsSeen === digitPosition) {
+        caretPosition = index + 1;
+        break;
+      }
+    }
+    input.value = formatted;
+    input.setSelectionRange(caretPosition, caretPosition);
+  });
 };
 
 // 단계 이동

--- a/src/components/approval/CreateApprovalPage.vue
+++ b/src/components/approval/CreateApprovalPage.vue
@@ -12,7 +12,7 @@
       <h2 class="text-xl font-semibold text-gray-900">결재 요청 작성</h2>
     </div>
     <!-- 진행 단계 표시 -->
-    <div class="mb-8">
+    <div v-if="!isPaymentRequest" class="mb-8">
         <div class="flex items-center space-x-4">
           <div 
             class="flex items-center"
@@ -54,7 +54,7 @@
         <!-- Step 1: 기본 정보 -->
         <div v-if="step === 1" class="space-y-6">
           <!-- 템플릿 선택 -->
-          <div>
+          <div v-if="!isPaymentRequest">
             <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 gap-2">
               <label class="block text-sm font-medium text-gray-700">
                 결재 양식 선택 (선택사항)
@@ -92,9 +92,17 @@
             <!-- 양식 목록 그리드 -->
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 max-h-[300px] overflow-y-auto p-1 bg-gray-50/50 rounded-lg border border-gray-100">
               <div
+                @click="selectPaymentRequest"
+                class="p-4 bg-white border rounded-lg cursor-pointer transition-all shadow-sm hover:shadow"
+                :class="isPaymentRequest ? 'border-blue-500 ring-1 ring-blue-500' : 'border-gray-200 hover:border-blue-300'"
+              >
+                <div class="font-medium text-gray-900 mb-1">납부 요청</div>
+                <div class="text-xs text-gray-500">기한·금액·납부 담당자를 지정하는 간편 결재</div>
+              </div>
+              <div
                 @click="handleTemplateSelect(null)"
                 class="p-4 bg-white border rounded-lg cursor-pointer transition-all shadow-sm hover:shadow"
-                :class="selectedTemplate === null ? 'border-blue-500 ring-1 ring-blue-500' : 'border-gray-200 hover:border-blue-300'"
+                :class="selectedTemplate === null && !isPaymentRequest ? 'border-blue-500 ring-1 ring-blue-500' : 'border-gray-200 hover:border-blue-300'"
               >
                 <div class="font-medium text-gray-900 mb-1">자유 작성</div>
                 <div class="text-xs text-gray-500">템플릿 없이 자유롭게 작성</div>
@@ -121,6 +129,44 @@
             </div>
           </div>
 
+          <div v-if="isPaymentRequest" class="space-y-4 rounded-lg border border-blue-100 bg-blue-50/50 p-5">
+            <div>
+              <h3 class="font-medium text-gray-900">납부 정보</h3>
+              <p class="mt-1 text-sm text-gray-600">최종 승인되면 지정 담당자의 ‘납부할 업무’에 자동으로 생성됩니다.</p>
+            </div>
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <label class="block text-sm font-medium text-gray-700">
+                납부 업무명
+                <input v-model="paymentRequest.name" type="text" placeholder="예: 2026년 1기 부가세" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+              </label>
+              <label class="block text-sm font-medium text-gray-700">
+                분류
+                <input v-model="paymentRequest.category" type="text" placeholder="예: 세금, 거래처 지급" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+              </label>
+              <label class="block text-sm font-medium text-gray-700">
+                요청 금액
+                <input v-model.number="paymentRequest.amount" min="0" type="number" placeholder="0" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+              </label>
+              <label class="block text-sm font-medium text-gray-700">
+                납부 기한
+                <input v-model="paymentRequest.due_date" type="date" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+              </label>
+              <label class="block text-sm font-medium text-gray-700 md:col-span-2">
+                납부 담당자 <span class="text-red-500">*</span>
+                <select v-model="paymentRequest.assignee_id" class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2">
+                  <option value="">담당자를 선택하세요</option>
+                  <option v-for="user in userStore.users" :key="user.user_id" :value="user.user_id">
+                    {{ user.name }} ({{ user.user_id }})
+                  </option>
+                </select>
+                <span class="mt-1 block text-xs font-normal text-gray-500">처음 선택한 담당자는 다음 납부 요청에도 기본값으로 적용됩니다.</span>
+              </label>
+            </div>
+            <p class="rounded-md bg-white px-3 py-2 text-sm text-gray-600">
+              자동 제목: <span class="font-medium text-gray-900">{{ paymentTitlePreview }}</span>
+            </p>
+          </div>
+
           <!-- 제목 -->
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-2">
@@ -129,8 +175,9 @@
             <input
               v-model="formData.title"
               type="text"
-              placeholder="결재 제목을 입력하세요"
-              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              :placeholder="isPaymentRequest ? '납부 정보 입력 시 자동 생성됩니다' : '결재 제목을 입력하세요'"
+              :readonly="isPaymentRequest"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 read-only:bg-gray-50"
               required
             />
           </div>
@@ -138,14 +185,14 @@
           <!-- 내용 -->
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-2">
-              내용 <span class="text-red-500">*</span>
+              {{ isPaymentRequest ? '요청 사유·참고사항 (선택)' : '내용' }}<span v-if="!isPaymentRequest" class="text-red-500"> *</span>
             </label>
             <textarea
               v-model="formData.content"
               rows="8"
-              placeholder="결재 내용을 입력하세요"
+              :placeholder="isPaymentRequest ? '납부 근거, 고지서 안내 등 필요한 내용을 입력하세요' : '결재 내용을 입력하세요'"
               class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-              required
+              :required="!isPaymentRequest"
             ></textarea>
           </div>
 
@@ -335,7 +382,7 @@
         <!-- 하단 버튼 -->
         <div class="flex justify-between items-center mt-8 pt-6 border-t">
           <button
-            v-if="step > 1"
+            v-if="step > 1 && !isPaymentRequest"
             @click="step--"
             class="flex items-center px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200"
           >
@@ -347,7 +394,16 @@
           <div class="flex space-x-3">
             <!-- 다음/완료 버튼 -->
             <button
-              v-if="step < 3"
+              v-if="isPaymentRequest"
+              @click="submitPaymentRequest"
+              :disabled="loading || !hasValidPaymentRequest"
+              class="flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+            >
+              <Loader v-if="loading" class="w-4 h-4 animate-spin mr-2" />
+              납부 요청 등록
+            </button>
+            <button
+              v-else-if="step < 3"
               @click="nextStep"
               :disabled="!canProceed"
               class="flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
@@ -416,8 +472,7 @@ import { ChevronLeft, ChevronRight, Users, Plus, Upload, Trash2, FileText, File,
 import { useToast } from 'vue-toastification';
 import { useTemplateStore } from '@/stores/useTemplateStore';
 import { useApprovalStore } from '@/stores/useApprovalStore';
-import { approvalUtils } from '@/utils/approvalApi';
-import { fileApi } from '@/utils/approvalApi';
+import { approvalUtils, fileApi, paymentTaskApi } from '@/utils/approvalApi';
 import ApprovalLineModal from './ApprovalLineModal.vue';
 import { useUserStore } from '@/stores/useUserStore';
 
@@ -444,6 +499,16 @@ const selectedFiles = ref([]);
 const deletedFileIds = ref([]);
 const fileInput = ref(null);
 const isDragOver = ref(false);
+const isPaymentRequest = ref(false);
+const PAYMENT_ASSIGNEE_STORAGE_KEY = 'payment_request_default_assignee_id';
+const createPaymentRequest = () => ({
+  name: '',
+  category: '',
+  amount: null,
+  due_date: '',
+  assignee_id: localStorage.getItem(PAYMENT_ASSIGNEE_STORAGE_KEY) || '',
+});
+const paymentRequest = ref(createPaymentRequest());
 
 // 폼 데이터
 const formData = ref({
@@ -456,6 +521,17 @@ const approvalLines = ref([]);
 const templates = ref([]);
 const templateSearchQuery = ref('');
 const selectedCategory = ref('all');
+
+const paymentTitlePreview = computed(() => {
+  const parts = ['납부 요청'];
+  if (paymentRequest.value.name.trim()) parts.push(paymentRequest.value.name.trim());
+  if (paymentRequest.value.due_date) parts.push(paymentRequest.value.due_date);
+  return parts.join(' - ');
+});
+
+const hasValidPaymentRequest = computed(() => {
+  return Boolean(paymentRequest.value.assignee_id);
+});
 
 // 템플릿 필터링 로직
 const templateCategories = computed(() => {
@@ -491,6 +567,8 @@ const goBack = () => {
 const resetForm = () => {
   step.value = 1;
   selectedTemplate.value = null;
+  isPaymentRequest.value = false;
+  paymentRequest.value = createPaymentRequest();
   formData.value = {
     title: '',
     content: '',
@@ -527,8 +605,29 @@ const handleTemplateSelect = (template) => {
   } else {
     // 자유 작성 선택
     selectedTemplate.value = null;
+    isPaymentRequest.value = false;
     formData.value.template_id = '';
     // 기존 제목, 내용, 결재선은 유지
+  }
+};
+
+const selectPaymentRequest = async () => {
+  if (!isPaymentRequest.value) {
+    const hasExistingData = formData.value.content.trim().length > 0 || approvalLines.value.length > 0;
+    if (hasExistingData && !confirm('납부 요청으로 전환하면 기존 제목과 내용을 납부 요청 형식으로 사용합니다. 계속하시겠습니까?')) {
+      return;
+    }
+  }
+  selectedTemplate.value = null;
+  formData.value.template_id = '';
+  isPaymentRequest.value = true;
+  await userStore.fetchAllUsers();
+  syncPaymentTitle();
+};
+
+const syncPaymentTitle = () => {
+  if (isPaymentRequest.value) {
+    formData.value.title = paymentTitlePreview.value;
   }
 };
 
@@ -541,6 +640,7 @@ const confirmTemplateChange = () => {
 };
 
 const applyTemplate = (template) => {
+  isPaymentRequest.value = false;
   selectedTemplate.value = template;
   formData.value.template_id = template.id;
   
@@ -603,7 +703,8 @@ const applyTemplate = (template) => {
 // 단계별 진행 조건
 const canProceed = computed(() => {
   if (step.value === 1) {
-    return formData.value.title.trim() && formData.value.content.trim();
+    return formData.value.title.trim() &&
+      (isPaymentRequest.value ? hasValidPaymentRequest.value : formData.value.content.trim());
   }
   if (step.value === 2) {
     return approvalLines.value.length > 0;
@@ -621,9 +722,10 @@ const hasInvalidApprovers = computed(() => {
 
 const canComplete = computed(() => {
   return formData.value.title.trim() && 
-         formData.value.content.trim() && 
+         (isPaymentRequest.value || formData.value.content.trim()) && 
          approvalLines.value.length > 0 &&
-         !hasInvalidApprovers.value;
+         !hasInvalidApprovers.value &&
+         (!isPaymentRequest.value || hasValidPaymentRequest.value);
 });
 
 // 파일 관련 함수들
@@ -734,6 +836,16 @@ const submitApproval = async () => {
   try {
     const requestData = {
       ...formData.value,
+      form_data: isPaymentRequest.value ? {
+        workflow_type: 'PAYMENT_REQUEST',
+        payment_request: {
+          ...paymentRequest.value,
+          amount: paymentRequest.value.amount === null || paymentRequest.value.amount === ''
+            ? null
+            : Number(paymentRequest.value.amount),
+          description: formData.value.content.trim(),
+        },
+      } : (formData.value.form_data || {}),
       approval_lines: approvalLines.value.map(line => ({
         step_order: line.step_order,
         approver_user_id: line.approver_user_id || line.approver_id,
@@ -762,6 +874,31 @@ const submitApproval = async () => {
   }
 };
 
+const submitPaymentRequest = async () => {
+  if (!hasValidPaymentRequest.value) {
+    toast.error('납부 담당자를 선택해주세요.');
+    return;
+  }
+
+  loading.value = true;
+  try {
+    const task = await paymentTaskApi.createTask({
+      ...paymentRequest.value,
+      amount: paymentRequest.value.amount === null || paymentRequest.value.amount === ''
+        ? null
+        : Number(paymentRequest.value.amount),
+      description: formData.value.content.trim(),
+      files: selectedFiles.value.filter(file => !file.id),
+    });
+    toast.success('납부 담당자에게 요청을 전달했습니다.');
+    emit('created', task);
+  } catch (error) {
+    toast.error('처리 중 오류가 발생했습니다: ' + error.message);
+  } finally {
+    loading.value = false;
+  }
+};
+
 // 기존 데이터 로드 (수정 모드)
 const loadExistingRequest = async () => {
   if (!props.editRequestId) return;
@@ -778,6 +915,17 @@ const loadExistingRequest = async () => {
       template_id: detail.template_id,
       form_data: detail.form_data || {},
     };
+
+    if (detail.form_data?.workflow_type === 'PAYMENT_REQUEST') {
+      isPaymentRequest.value = true;
+      paymentRequest.value = {
+        name: detail.form_data.payment_request?.name || '',
+        category: detail.form_data.payment_request?.category || '',
+        amount: detail.form_data.payment_request?.amount ?? null,
+        due_date: detail.form_data.payment_request?.due_date || '',
+        assignee_id: detail.form_data.payment_request?.assignee_id || '',
+      };
+    }
     
     approvalLines.value = lines.map(line => ({
       ...line,
@@ -809,9 +957,14 @@ const loadExistingRequest = async () => {
 // 초기 로드
 onMounted(async () => {
   resetForm();
-  await loadTemplates();
+  await Promise.all([loadTemplates(), userStore.fetchAllUsers()]);
   if (props.editRequestId) {
     await loadExistingRequest();
   }
+});
+
+watch(paymentRequest, syncPaymentTitle, { deep: true });
+watch(() => paymentRequest.value.assignee_id, assigneeId => {
+  if (assigneeId) localStorage.setItem(PAYMENT_ASSIGNEE_STORAGE_KEY, assigneeId);
 });
 </script>

--- a/src/components/approval/PaymentTaskList.vue
+++ b/src/components/approval/PaymentTaskList.vue
@@ -15,7 +15,24 @@
       </button>
     </div>
 
-    <div class="mb-5 grid grid-cols-1 gap-3 sm:grid-cols-3">
+    <div class="mb-5 border-b border-gray-200">
+      <div class="flex gap-5" role="tablist" aria-label="납부 업무 구분">
+        <button
+          v-for="scope in taskScopes"
+          :key="scope.id"
+          type="button"
+          role="tab"
+          :aria-selected="selectedScope === scope.id"
+          class="border-b-2 px-1 pb-3 text-sm font-medium transition-colors"
+          :class="selectedScope === scope.id ? 'border-blue-600 text-blue-700' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'"
+          @click="selectedScope = scope.id"
+        >
+          {{ scope.label }} <span class="ml-1 text-xs">{{ scope.count }}건</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="mb-5 grid grid-cols-2 gap-3 lg:grid-cols-4">
       <button v-for="filter in filters" :key="filter.id" type="button" class="rounded-lg border p-4 text-left transition-colors" :class="selectedFilter === filter.id ? filter.activeClass : 'border-gray-200 bg-white hover:bg-gray-50'" @click="selectedFilter = filter.id">
         <p class="text-sm" :class="selectedFilter === filter.id ? '' : 'text-gray-600'">{{ filter.label }}</p>
         <p class="mt-1 text-2xl font-bold">{{ filter.count }}건</p>
@@ -26,59 +43,34 @@
     <div v-else-if="filteredTasks.length === 0" class="rounded-lg border border-dashed border-gray-300 bg-white py-12 text-center text-gray-500">
       조건에 맞는 납부 업무가 없습니다.
     </div>
-    <div v-else class="space-y-3">
-      <article v-for="task in filteredTasks" :key="task.id" class="rounded-lg border bg-white p-5 shadow-sm">
-        <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div class="min-w-0">
-            <div class="mb-2 flex flex-wrap items-center gap-2">
-              <span class="rounded-full px-2.5 py-1 text-xs font-medium" :class="statusClass(task)">
-                {{ statusLabel(task) }}
-              </span>
-              <span v-if="task.category" class="text-sm text-gray-500">{{ task.category }}</span>
-            </div>
-            <h3 class="truncate text-lg font-semibold text-gray-900">{{ task.title }}</h3>
-            <p class="mt-1 text-sm text-gray-600">{{ task.description || '등록된 요청 사유가 없습니다.' }}</p>
+    <div v-else class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <article v-for="task in filteredTasks" :key="task.id" class="flex min-w-0 flex-col rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md">
+        <div class="min-w-0">
+          <div class="mb-2 flex flex-wrap items-center gap-2">
+            <span class="rounded-full px-2.5 py-1 text-xs font-medium" :class="statusClass(task)">
+              {{ statusLabel(task) }}
+            </span>
+            <span v-if="task.category" class="text-sm text-gray-500">{{ task.category }}</span>
           </div>
-
-          <div class="grid grid-cols-2 gap-x-7 gap-y-2 text-sm sm:grid-cols-3 lg:shrink-0">
-            <div><p class="text-gray-500">요청 금액</p><p class="font-semibold">{{ formatAmount(task.requested_amount) }}</p></div>
-            <div><p class="text-gray-500">납부 기한</p><p class="font-semibold" :class="dueDateClass(task)">{{ formatDate(task.due_date) }}</p></div>
-            <div><p class="text-gray-500">남은 기간</p><p class="font-semibold" :class="dueDateClass(task)">{{ dueLabel(task) }}</p></div>
-          </div>
-
-          <button
-            v-if="canEditTask(task)"
-            type="button"
-            class="shrink-0 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-            @click="openEditModal(task)"
-          >
-            요청 수정
-          </button>
-          <button
-            v-if="canProcessTask(task) && !task.is_request_confirmed"
-            type="button"
-            class="shrink-0 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
-            @click="confirmTask(task)"
-          >
-            요청 확인
-          </button>
-          <button
-            v-else-if="canProcessTask(task) && task.status === 'PENDING_SETUP'"
-            type="button"
-            class="shrink-0 rounded-md bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700"
-            @click="openDueDateModal(task)"
-          >
-            기한 설정
-          </button>
-          <button
-            v-else-if="canProcessTask(task) && task.status !== 'COMPLETED'"
-            type="button"
-            class="shrink-0 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-            @click="openCompleteModal(task)"
-          >
-            납부 완료 처리
-          </button>
+          <h3 class="truncate text-lg font-semibold text-gray-900" :title="task.title">{{ task.title }}</h3>
+          <p class="mt-1 min-h-10 text-sm leading-5 text-gray-600 line-clamp-2">{{ task.description || '등록된 요청 사유가 없습니다.' }}</p>
         </div>
+
+        <dl class="mt-4 grid grid-cols-2 gap-2 text-sm">
+          <div class="col-span-2 rounded-md bg-gray-50 p-2.5">
+            <dt class="text-xs text-gray-500">요청 금액</dt>
+            <dd class="mt-1 break-keep font-semibold text-gray-900">{{ formatAmount(task.requested_amount) }}</dd>
+          </div>
+          <div class="rounded-md bg-gray-50 p-2.5">
+            <dt class="text-xs text-gray-500">납부 기한</dt>
+            <dd class="mt-1 font-semibold" :class="dueDateClass(task)">{{ formatDate(task.due_date) }}</dd>
+          </div>
+          <div class="rounded-md bg-gray-50 p-2.5">
+            <dt class="text-xs text-gray-500">남은 기간</dt>
+            <dd class="mt-1 font-semibold" :class="dueDateClass(task)">{{ dueLabel(task) }}</dd>
+          </div>
+        </dl>
+
         <div v-if="task.status === 'COMPLETED'" class="mt-4 border-t pt-3 text-sm text-gray-600">
           {{ formatDate(task.paid_at) }} 납부 · {{ formatAmount(task.paid_amount) }} · 증빙 {{ task.receipt_file_ids.length }}개
         </div>
@@ -98,10 +90,52 @@
             </button>
           </div>
         </div>
+        <div v-if="canEditTask(task) || canManageCompletedFiles(task) || (canProcessTask(task) && task.status !== 'COMPLETED')" class="mt-auto flex flex-wrap justify-end gap-2 pt-4">
+          <button
+            v-if="canEditTask(task)"
+            type="button"
+            class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            @click="openEditModal(task)"
+          >
+            요청 수정
+          </button>
+          <button
+            v-if="canManageCompletedFiles(task)"
+            type="button"
+            class="rounded-md border border-green-300 bg-green-50 px-4 py-2 text-sm font-medium text-green-700 hover:bg-green-100"
+            @click="openEditModal(task, true)"
+          >
+            납부 내역 수정
+          </button>
+          <button
+            v-if="canProcessTask(task) && !task.is_request_confirmed"
+            type="button"
+            class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+            @click="confirmTask(task)"
+          >
+            요청 확인
+          </button>
+          <button
+            v-else-if="canProcessTask(task) && task.status === 'PENDING_SETUP'"
+            type="button"
+            class="rounded-md bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700"
+            @click="openDueDateModal(task)"
+          >
+            기한 설정
+          </button>
+          <button
+            v-else-if="canProcessTask(task) && task.status !== 'COMPLETED'"
+            type="button"
+            class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            @click="openCompleteModal(task)"
+          >
+            납부 완료 처리
+          </button>
+        </div>
       </article>
     </div>
 
-    <div v-if="selectedTask" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="closeModal">
+    <div v-if="selectedTask" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @mousedown.self="closeModal">
       <form class="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl" @submit.prevent="completeTask">
         <h3 class="text-lg font-semibold text-gray-900">납부 완료 처리</h3>
         <p class="mt-1 text-sm text-gray-500">{{ selectedTask.title }}</p>
@@ -109,24 +143,43 @@
           <label class="block text-sm font-medium text-gray-700">실제 납부일
             <input v-model="completionForm.paidAt" required type="date" class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2" />
           </label>
-          <label class="block text-sm font-medium text-gray-700">실제 납부 금액
-            <input v-model.number="completionForm.paidAmount" required min="0" type="number" class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2" />
+          <label class="block text-sm font-medium text-gray-700">실제 납부 금액 <span class="text-gray-400">(선택)</span>
+            <input :value="formatAmountInput(completionForm.paidAmount)" inputmode="numeric" type="text" class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2" placeholder="금액을 입력하세요" @input="updateAmountInput($event, value => (completionForm.paidAmount = value))" />
           </label>
           <div>
-            <p class="text-sm font-medium text-gray-700">납부확인증 <span class="text-red-500">*</span></p>
+            <p class="text-sm font-medium text-gray-700">납부확인증 <span class="text-gray-400">(선택)</span></p>
             <div
-              class="mt-1 rounded-lg border-2 border-dashed p-5 text-center transition-colors"
-              :class="isReceiptDragOver ? 'border-blue-500 bg-blue-50' : 'border-gray-300 bg-gray-50'"
+              class="mt-1 rounded-lg border-2 border-dashed p-6 text-center transition-colors"
+              :class="isReceiptDragOver ? 'border-blue-400 bg-blue-50' : 'border-gray-300'"
               @dragenter.prevent="isReceiptDragOver = true"
               @dragover.prevent="isReceiptDragOver = true"
               @dragleave.prevent="isReceiptDragOver = false"
               @drop.prevent="handleReceiptDrop"
             >
-              <p class="text-sm text-gray-700">파일을 이곳으로 끌어다 놓거나 아래에서 선택하세요.</p>
-              <input required multiple type="file" class="mx-auto mt-3 block max-w-xs text-sm" @change="handleReceiptFiles" />
-              <p class="mt-2 text-xs text-gray-500">납부확인증, 이체확인증 등 증빙 파일을 첨부합니다.</p>
+              <input ref="receiptFileInput" multiple type="file" class="hidden" @change="handleReceiptFiles" />
+              <Upload class="mx-auto mb-4 h-12 w-12 text-gray-400" />
+              <p class="mb-2 text-gray-500">증빙파일을 드래그하거나 클릭하여 업로드</p>
+              <button type="button" class="inline-flex items-center rounded-md bg-gray-100 px-4 py-2 text-gray-700 hover:bg-gray-200" @click="receiptFileInput?.click()">
+                파일 선택
+              </button>
             </div>
-            <p v-if="completionForm.receiptFiles.length" class="mt-2 text-xs text-gray-600">선택됨: {{ completionForm.receiptFiles.map(file => file.name).join(', ') }}</p>
+            <div v-if="completionForm.receiptFiles.length" class="mt-4 space-y-2">
+              <h5 class="font-medium text-gray-900">선택된 파일</h5>
+              <div class="max-h-44 space-y-2 overflow-y-auto pr-1">
+                <div v-for="(file, index) in completionForm.receiptFiles" :key="`${file.name}-${file.lastModified}`" class="flex items-center justify-between rounded-md bg-gray-50 p-3">
+                  <div class="flex min-w-0 items-center space-x-3">
+                    <component :is="getFileIcon(file.name)" class="h-5 w-5 shrink-0 text-gray-400" />
+                    <div class="min-w-0">
+                      <p class="truncate font-medium text-gray-900">{{ file.name }}</p>
+                      <p class="text-sm text-gray-500">{{ formatFileSize(file.size) }}</p>
+                    </div>
+                  </div>
+                  <button type="button" class="p-1 text-red-500 hover:text-red-700" :aria-label="`${file.name} 삭제`" @click="removeReceiptFile(index)">
+                    <X class="h-5 w-5" />
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
           <label class="block text-sm font-medium text-gray-700">메모
             <textarea v-model="completionForm.note" rows="3" class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2" placeholder="거래번호나 참고사항을 입력하세요." />
@@ -141,7 +194,7 @@
       </form>
     </div>
 
-    <div v-if="dueDateTask" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="closeDueDateModal">
+    <div v-if="dueDateTask" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @mousedown.self="closeDueDateModal">
       <form class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl" @submit.prevent="setDueDate">
         <h3 class="text-lg font-semibold text-gray-900">납부 기한 설정</h3>
         <p class="mt-1 text-sm text-gray-500">{{ dueDateTask.title }}</p>
@@ -157,43 +210,77 @@
       </form>
     </div>
 
-    <div v-if="editingTask" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="closeEditModal">
+    <div v-if="editingTask" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @mousedown.self="closeEditModal">
       <form class="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg bg-white p-6 shadow-xl" @submit.prevent="updateTask">
-        <h3 class="text-lg font-semibold text-gray-900">납부 요청 수정</h3>
-        <p class="mt-1 text-sm text-gray-500">납부 담당자가 요청을 확인하기 전까지 수정할 수 있습니다.</p>
-        <div class="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <h3 class="text-lg font-semibold text-gray-900">{{ editingFilesOnly ? '납부 내역 수정' : '납부 요청 수정' }}</h3>
+        <p class="mt-1 text-sm text-gray-500">{{ editingFilesOnly ? '실제 납부일, 금액, 메모와 증빙파일을 보완할 수 있습니다.' : '납부 담당자가 요청을 확인하기 전까지 수정할 수 있습니다.' }}</p>
+        <div v-if="editingFilesOnly" class="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <label class="text-sm font-medium text-gray-700">실제 납부일<input v-model="editForm.paidAt" required type="date" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
+          <label class="text-sm font-medium text-gray-700">실제 납부 금액 <span class="text-gray-400">(선택)</span><input :value="formatAmountInput(editForm.paidAmount)" inputmode="numeric" type="text" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" placeholder="금액을 입력하세요" @input="updateAmountInput($event, value => (editForm.paidAmount = value))" /></label>
+          <label class="text-sm font-medium text-gray-700 sm:col-span-2">메모<textarea v-model="editForm.completionNote" rows="3" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" placeholder="거래번호나 참고사항을 입력하세요." /></label>
+        </div>
+        <div v-if="!editingFilesOnly" class="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2">
           <label class="text-sm font-medium text-gray-700">업무명<input v-model="editForm.name" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
           <label class="text-sm font-medium text-gray-700">분류<input v-model="editForm.category" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
-          <label class="text-sm font-medium text-gray-700">요청 금액<input v-model="editForm.amount" min="0" type="number" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
+          <label class="text-sm font-medium text-gray-700">요청 금액<input :value="formatAmountInput(editForm.amount)" inputmode="numeric" type="text" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" placeholder="금액을 입력하세요" @input="updateAmountInput($event, value => (editForm.amount = value))" /></label>
           <label class="text-sm font-medium text-gray-700">납부 기한<input v-model="editForm.dueDate" type="date" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
           <label class="text-sm font-medium text-gray-700 sm:col-span-2">요청 사유<textarea v-model="editForm.description" rows="3" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
         </div>
         <div class="mt-5">
-          <p class="text-sm font-medium text-gray-700">기존 첨부파일</p>
-          <div v-if="editFiles.length" class="mt-2 space-y-2">
-            <div v-for="file in editFiles" :key="file.id" class="flex items-center justify-between rounded border border-gray-200 px-3 py-2 text-sm">
-              <span>{{ file.file_name }}</span>
-              <button type="button" class="text-red-600 hover:text-red-800" @click="removeEditFile(file.id)">삭제</button>
+          <p class="text-sm font-medium text-gray-700">{{ editingFilesOnly ? '기존 납부 증빙' : '기존 첨부파일' }}</p>
+          <div v-if="editFiles.length" class="mt-2 max-h-44 space-y-2 overflow-y-auto pr-1">
+            <div v-for="file in editFiles" :key="file.id" class="flex items-center justify-between rounded-md bg-gray-50 p-3">
+              <div class="flex min-w-0 items-center space-x-3">
+                <component :is="getFileIcon(file.file_name)" class="h-5 w-5 shrink-0 text-gray-400" />
+                <div class="min-w-0">
+                  <p class="truncate font-medium text-gray-900">{{ file.file_name }}</p>
+                  <p class="text-sm text-gray-500">{{ formatFileSize(file.file_size) }}</p>
+                </div>
+              </div>
+              <button type="button" class="p-1 text-red-500 hover:text-red-700" :aria-label="`${file.file_name} 삭제`" @click="removeEditFile(file.id)">
+                <X class="h-5 w-5" />
+              </button>
             </div>
           </div>
-          <p v-else class="mt-2 text-sm text-gray-500">첨부파일이 없습니다.</p>
+          <p v-else class="mt-2 text-sm text-gray-500">{{ editingFilesOnly ? '등록된 납부 증빙이 없습니다.' : '첨부파일이 없습니다.' }}</p>
         </div>
         <div class="mt-4">
-          <p class="text-sm font-medium text-gray-700">추가 첨부파일</p>
-          <div class="mt-1 rounded-lg border-2 border-dashed p-4 text-center" :class="isEditDragOver ? 'border-blue-500 bg-blue-50' : 'border-gray-300 bg-gray-50'" @dragenter.prevent="isEditDragOver = true" @dragover.prevent="isEditDragOver = true" @dragleave.prevent="isEditDragOver = false" @drop.prevent="handleEditDrop">
-            <p class="text-sm text-gray-700">파일을 이곳으로 끌어다 놓거나 선택하세요.</p>
-            <input multiple type="file" class="mx-auto mt-2 block max-w-xs text-sm" @change="handleEditFiles" />
+          <p class="text-sm font-medium text-gray-700">{{ editingFilesOnly ? '추가 납부 증빙' : '추가 첨부파일' }}</p>
+          <div class="mt-1 rounded-lg border-2 border-dashed p-6 text-center transition-colors" :class="isEditDragOver ? 'border-blue-400 bg-blue-50' : 'border-gray-300'" @dragenter.prevent="isEditDragOver = true" @dragover.prevent="isEditDragOver = true" @dragleave.prevent="isEditDragOver = false" @drop.prevent="handleEditDrop">
+            <input ref="editFileInput" multiple type="file" class="hidden" @change="handleEditFiles" />
+            <Upload class="mx-auto mb-4 h-12 w-12 text-gray-400" />
+            <p class="mb-2 text-gray-500">{{ editingFilesOnly ? '증빙파일을 드래그하거나 클릭하여 업로드' : '파일을 드래그하거나 클릭하여 업로드' }}</p>
+            <button type="button" class="inline-flex items-center rounded-md bg-gray-100 px-4 py-2 text-gray-700 hover:bg-gray-200" @click="editFileInput?.click()">
+              파일 선택
+            </button>
           </div>
-          <p v-if="editForm.newFiles.length" class="mt-2 text-xs text-gray-600">추가됨: {{ editForm.newFiles.map(file => file.name).join(', ') }}</p>
+          <div v-if="editForm.newFiles.length" class="mt-4 space-y-2">
+            <h5 class="font-medium text-gray-900">선택된 파일</h5>
+            <div class="max-h-44 space-y-2 overflow-y-auto pr-1">
+              <div v-for="(file, index) in editForm.newFiles" :key="`${file.name}-${file.lastModified}`" class="flex items-center justify-between rounded-md bg-gray-50 p-3">
+                <div class="flex min-w-0 items-center space-x-3">
+                  <component :is="getFileIcon(file.name)" class="h-5 w-5 shrink-0 text-gray-400" />
+                  <div class="min-w-0">
+                    <p class="truncate font-medium text-gray-900">{{ file.name }}</p>
+                    <p class="text-sm text-gray-500">{{ formatFileSize(file.size) }}</p>
+                  </div>
+                </div>
+                <button type="button" class="p-1 text-red-500 hover:text-red-700" :aria-label="`${file.name} 삭제`" @click="removeNewEditFile(index)">
+                  <X class="h-5 w-5" />
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="mt-6 flex justify-end gap-3"><button type="button" class="rounded-md bg-gray-100 px-4 py-2 text-sm text-gray-700" @click="closeEditModal">취소</button><button type="submit" class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50" :disabled="updating">{{ updating ? '저장 중...' : '수정 저장' }}</button></div>
+        <div class="mt-6 flex justify-end gap-3"><button type="button" class="rounded-md bg-gray-100 px-4 py-2 text-sm text-gray-700" @click="closeEditModal">취소</button><button type="submit" class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50" :disabled="updating">{{ updating ? '저장 중...' : editingFilesOnly ? '납부 내역 저장' : '수정 저장' }}</button></div>
       </form>
     </div>
   </section>
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue';
+import { computed, nextTick, onMounted, ref } from 'vue';
+import { File, FileText, Upload, X } from 'lucide-vue-next';
 import { useToast } from 'vue-toastification';
 import { paymentTaskApi } from '@/utils/approvalApi';
 import { useUserStore } from '@/stores/useUserStore';
@@ -210,34 +297,52 @@ const dueDateTask = ref(null);
 const dueDateInput = ref('');
 const completionForm = ref({ paidAt: '', paidAmount: 0, note: '', receiptFiles: [] });
 const isReceiptDragOver = ref(false);
+const receiptFileInput = ref(null);
 const isEditDragOver = ref(false);
+const editFileInput = ref(null);
 const taskFiles = ref({});
+const selectedScope = ref('ASSIGNED');
 const selectedFilter = ref('ALL');
 const editingTask = ref(null);
+const editingFilesOnly = ref(false);
 const updating = ref(false);
 const editFiles = ref([]);
-const editForm = ref({ name: '', category: '', amount: '', dueDate: '', description: '', newFiles: [], deletedFileIds: [] });
+const editForm = ref({ name: '', category: '', amount: '', dueDate: '', description: '', paidAt: '', paidAmount: '', completionNote: '', newFiles: [], deletedFileIds: [] });
 
 const today = () => new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' });
+const currentUserId = computed(() => userStore.currentUser?.user_id || userStore.currentUser?.id);
 const dateDiff = dueDate => dueDate
   ? Math.ceil((new Date(`${dueDate}T00:00:00`) - new Date(`${today()}T00:00:00`)) / 86400000)
   : null;
 const isOpenTask = task => task.status !== 'COMPLETED';
-const todayTasks = computed(() => tasks.value.filter(task => isOpenTask(task) && dateDiff(task.due_date) === 0));
-const soonTasks = computed(() => tasks.value.filter(task => isOpenTask(task) && dateDiff(task.due_date) >= 1 && dateDiff(task.due_date) <= 3));
+const scopedTasks = computed(() => tasks.value.filter(task => selectedScope.value === 'ASSIGNED'
+  ? task.assignee_id === currentUserId.value
+  : task.requester_id === currentUserId.value));
+const taskScopes = computed(() => [
+  { id: 'ASSIGNED', label: '요청 받은 업무', count: tasks.value.filter(task => task.assignee_id === currentUserId.value).length },
+  { id: 'REQUESTED', label: '내가 요청한 업무', count: tasks.value.filter(task => task.requester_id === currentUserId.value).length },
+]);
+const todayTasks = computed(() => scopedTasks.value.filter(task => isOpenTask(task) && dateDiff(task.due_date) === 0));
+const soonTasks = computed(() => scopedTasks.value.filter(task => isOpenTask(task) && dateDiff(task.due_date) >= 1 && dateDiff(task.due_date) <= 3));
+const completedTasks = computed(() => scopedTasks.value.filter(task => task.status === 'COMPLETED'));
 const filters = computed(() => [
   { id: 'SOON', label: '3일 이내 마감', count: soonTasks.value.length, activeClass: 'border-amber-300 bg-amber-50 text-amber-800' },
   { id: 'TODAY', label: '당일 마감', count: todayTasks.value.length, activeClass: 'border-blue-300 bg-blue-50 text-blue-800' },
-  { id: 'ALL', label: '전체 업무', count: tasks.value.length, activeClass: 'border-gray-400 bg-gray-100 text-gray-900' },
+  { id: 'COMPLETED', label: '납부 완료', count: completedTasks.value.length, activeClass: 'border-green-300 bg-green-50 text-green-800' },
+  { id: 'ALL', label: '전체 업무', count: scopedTasks.value.length, activeClass: 'border-gray-400 bg-gray-100 text-gray-900' },
 ]);
-const filteredTasks = computed(() => selectedFilter.value === 'TODAY'
-  ? todayTasks.value
-  : selectedFilter.value === 'SOON' ? soonTasks.value : tasks.value);
+const filteredTasks = computed(() => {
+  if (selectedFilter.value === 'TODAY') return todayTasks.value;
+  if (selectedFilter.value === 'SOON') return soonTasks.value;
+  if (selectedFilter.value === 'COMPLETED') return completedTasks.value;
+  return scopedTasks.value;
+});
 
 const loadTasks = async () => {
   loading.value = true;
   try {
-    tasks.value = await paymentTaskApi.getMyTasks();
+    const loadedTasks = await paymentTaskApi.getMyTasks();
+    tasks.value = [...loadedTasks].sort((left, right) => Number(left.status === 'COMPLETED') - Number(right.status === 'COMPLETED'));
   } catch (error) {
     toast.error(error.message || '납부 업무를 불러오지 못했습니다.');
   } finally {
@@ -254,6 +359,32 @@ const refreshSummary = async () => {
 };
 
 const formatAmount = value => value === null || value === undefined ? '-' : `${Number(value).toLocaleString('ko-KR')}원`;
+const formatAmountInput = value => value === null || value === undefined || value === '' ? '' : Number(value).toLocaleString('ko-KR');
+const parseAmountInput = value => {
+  const digits = String(value).replace(/[^0-9]/g, '');
+  return digits ? Number(digits) : '';
+};
+const updateAmountInput = (event, updateValue) => {
+  const input = event.target;
+  const digitPosition = input.value.slice(0, input.selectionStart ?? input.value.length).replace(/[^0-9]/g, '').length;
+  const amount = parseAmountInput(input.value);
+  updateValue(amount);
+
+  nextTick(() => {
+    const formatted = formatAmountInput(amount);
+    let digitsSeen = 0;
+    let caretPosition = formatted.length;
+    for (let index = 0; index < formatted.length; index += 1) {
+      if (/\d/.test(formatted[index])) digitsSeen += 1;
+      if (digitsSeen === digitPosition) {
+        caretPosition = index + 1;
+        break;
+      }
+    }
+    input.value = formatted;
+    input.setSelectionRange(caretPosition, caretPosition);
+  });
+};
 const formatDate = value => value ? new Intl.DateTimeFormat('ko-KR', { dateStyle: 'medium' }).format(new Date(`${value}T00:00:00`)) : '-';
 const statusLabel = task => ({ COMPLETED: '납부 완료', PENDING_PAYMENT: '납부 대기', PENDING_SETUP: '기한 설정 필요' })[task.status] || '납부 대기';
 const statusClass = task => task.status === 'COMPLETED' ? 'bg-green-100 text-green-700' : task.status === 'PENDING_SETUP' ? 'bg-slate-100 text-slate-700' : 'bg-amber-100 text-amber-700';
@@ -264,8 +395,9 @@ const dueLabel = task => {
   const diff = dateDiff(task.due_date);
   return diff < 0 ? '-' : diff === 0 ? 'D-day' : `D-${diff}`;
 };
-const canProcessTask = task => task.assignee_id === (userStore.currentUser?.user_id || userStore.currentUser?.id);
-const canEditTask = task => task.requester_id === (userStore.currentUser?.user_id || userStore.currentUser?.id) && !task.is_request_confirmed && task.status !== 'COMPLETED';
+const canProcessTask = task => task.assignee_id === currentUserId.value;
+const canEditTask = task => task.requester_id === currentUserId.value && !task.is_request_confirmed && task.status !== 'COMPLETED';
+const canManageCompletedFiles = task => canProcessTask(task) && task.status === 'COMPLETED';
 
 const openCompleteModal = task => {
   selectedTask.value = task;
@@ -277,29 +409,67 @@ const openDueDateModal = task => {
   dueDateInput.value = task.due_date || today();
 };
 const closeDueDateModal = () => { dueDateTask.value = null; };
-const openEditModal = async task => {
+const openEditModal = async (task, filesOnly = false) => {
   editingTask.value = task;
+  editingFilesOnly.value = filesOnly;
   editForm.value = {
     name: task.request_name || '',
     category: task.category || '',
     amount: task.requested_amount ?? '',
     dueDate: task.due_date || '',
     description: task.description || '',
+    paidAt: task.paid_at || '',
+    paidAmount: task.paid_amount ?? '',
+    completionNote: task.completion_note || '',
     newFiles: [],
     deletedFileIds: [],
   };
   try {
-    editFiles.value = await paymentTaskApi.getTaskFiles(task.id);
+    const files = await paymentTaskApi.getTaskFiles(task.id);
+    editFiles.value = filesOnly ? files.filter(file => task.receipt_file_ids?.includes(file.id)) : files;
   } catch (error) {
     editFiles.value = [];
     toast.error('기존 첨부파일을 불러오지 못했습니다.');
   }
 };
-const closeEditModal = () => { editingTask.value = null; };
-const handleEditFiles = event => { editForm.value.newFiles = Array.from(event.target.files || []); };
+const closeEditModal = () => {
+  editingTask.value = null;
+  editingFilesOnly.value = false;
+};
+const addEditFiles = files => {
+  const maxSize = 20 * 1024 * 1024;
+  const existingNames = new Set(editForm.value.newFiles.map(file => file.name));
+  const filesToAdd = files.filter(file => {
+    if (file.size > maxSize) {
+      toast.error(`${file.name}은(는) 20MB를 초과합니다.`);
+      return false;
+    }
+    if (existingNames.has(file.name)) {
+      toast.error(`${file.name}은(는) 이미 추가되었습니다.`);
+      return false;
+    }
+    return true;
+  });
+  editForm.value.newFiles = [...editForm.value.newFiles, ...filesToAdd];
+};
+const handleEditFiles = event => {
+  addEditFiles(Array.from(event.target.files || []));
+  event.target.value = '';
+};
 const handleEditDrop = event => {
   isEditDragOver.value = false;
-  editForm.value.newFiles = Array.from(event.dataTransfer.files || []);
+  addEditFiles(Array.from(event.dataTransfer.files || []));
+};
+const removeNewEditFile = index => { editForm.value.newFiles.splice(index, 1); };
+const formatFileSize = size => {
+  if (size === undefined || size === null) return '-';
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+};
+const getFileIcon = fileName => {
+  const extension = fileName?.split('.').pop()?.toLowerCase();
+  return ['jpg', 'jpeg', 'png', 'gif'].includes(extension) ? FileText : File;
 };
 const removeEditFile = fileId => {
   editForm.value.deletedFileIds.push(fileId);
@@ -308,16 +478,31 @@ const removeEditFile = fileId => {
 const updateTask = async () => {
   updating.value = true;
   try {
-    await paymentTaskApi.updateTask(editingTask.value.id, {
-      name: editForm.value.name,
-      category: editForm.value.category,
-      amount: editForm.value.amount === '' ? undefined : Number(editForm.value.amount),
-      due_date: editForm.value.dueDate,
-      description: editForm.value.description,
+    const taskUpdate = {
       files: editForm.value.newFiles,
       deletedFileIds: editForm.value.deletedFileIds,
-    });
-    toast.success('납부 요청을 수정했습니다.');
+    };
+    if (!editingFilesOnly.value) {
+      Object.assign(taskUpdate, {
+        name: editForm.value.name,
+        category: editForm.value.category,
+        amount: editForm.value.amount === '' ? undefined : Number(editForm.value.amount),
+        due_date: editForm.value.dueDate,
+        description: editForm.value.description,
+      });
+    }
+    if (editingFilesOnly.value) {
+      await paymentTaskApi.updateCompletion(editingTask.value.id, {
+        paidAt: editForm.value.paidAt,
+        paidAmount: editForm.value.paidAmount,
+        note: editForm.value.completionNote,
+        receiptFiles: taskUpdate.files,
+        deletedFileIds: taskUpdate.deletedFileIds,
+      });
+    } else {
+      await paymentTaskApi.updateTask(editingTask.value.id, taskUpdate);
+    }
+    toast.success(editingFilesOnly.value ? '납부 내역을 수정했습니다.' : '납부 요청을 수정했습니다.');
     closeEditModal();
     await loadTasks();
   } catch (error) {
@@ -361,20 +546,36 @@ const downloadRequestFile = async (task, file) => {
     toast.error(error.message || '첨부파일 다운로드에 실패했습니다.');
   }
 };
-const handleReceiptFiles = event => { completionForm.value.receiptFiles = Array.from(event.target.files || []); };
+const addReceiptFiles = files => {
+  const maxSize = 20 * 1024 * 1024;
+  const existingNames = new Set(completionForm.value.receiptFiles.map(file => file.name));
+  const filesToAdd = files.filter(file => {
+    if (file.size > maxSize) {
+      toast.error(`${file.name}은(는) 20MB를 초과합니다.`);
+      return false;
+    }
+    if (existingNames.has(file.name)) {
+      toast.error(`${file.name}은(는) 이미 추가되었습니다.`);
+      return false;
+    }
+    return true;
+  });
+  completionForm.value.receiptFiles = [...completionForm.value.receiptFiles, ...filesToAdd];
+};
+const handleReceiptFiles = event => {
+  addReceiptFiles(Array.from(event.target.files || []));
+  event.target.value = '';
+};
 const handleReceiptDrop = event => {
   isReceiptDragOver.value = false;
-  completionForm.value.receiptFiles = Array.from(event.dataTransfer.files || []);
+  addReceiptFiles(Array.from(event.dataTransfer.files || []));
 };
+const removeReceiptFile = index => { completionForm.value.receiptFiles.splice(index, 1); };
 const completeTask = async () => {
-  if (!completionForm.value.receiptFiles.length) {
-    toast.warning('납부확인증을 첨부해주세요.');
-    return;
-  }
   completing.value = true;
   try {
     await paymentTaskApi.completeTask(selectedTask.value.id, completionForm.value);
-    toast.success('납부 완료와 증빙이 등록되었습니다.');
+    toast.success(completionForm.value.receiptFiles.length ? '납부 완료와 증빙이 등록되었습니다.' : '납부 완료 처리되었습니다.');
     closeModal();
     await loadTasks();
     await refreshSummary();

--- a/src/components/approval/PaymentTaskList.vue
+++ b/src/components/approval/PaymentTaskList.vue
@@ -1,0 +1,408 @@
+<template>
+  <section>
+    <div class="mb-6 flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <h2 class="text-2xl font-bold text-gray-900">납부 업무</h2>
+        <p class="mt-1 text-gray-600">내가 요청했거나 담당 중인 납부 업무를 확인하고 처리합니다.</p>
+      </div>
+      <button
+        type="button"
+        class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        :disabled="loading"
+        @click="loadTasks"
+      >
+        새로고침
+      </button>
+    </div>
+
+    <div class="mb-5 grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <button v-for="filter in filters" :key="filter.id" type="button" class="rounded-lg border p-4 text-left transition-colors" :class="selectedFilter === filter.id ? filter.activeClass : 'border-gray-200 bg-white hover:bg-gray-50'" @click="selectedFilter = filter.id">
+        <p class="text-sm" :class="selectedFilter === filter.id ? '' : 'text-gray-600'">{{ filter.label }}</p>
+        <p class="mt-1 text-2xl font-bold">{{ filter.count }}건</p>
+      </button>
+    </div>
+
+    <div v-if="loading" class="py-12 text-center text-gray-500">납부 업무를 불러오는 중입니다.</div>
+    <div v-else-if="filteredTasks.length === 0" class="rounded-lg border border-dashed border-gray-300 bg-white py-12 text-center text-gray-500">
+      조건에 맞는 납부 업무가 없습니다.
+    </div>
+    <div v-else class="space-y-3">
+      <article v-for="task in filteredTasks" :key="task.id" class="rounded-lg border bg-white p-5 shadow-sm">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div class="min-w-0">
+            <div class="mb-2 flex flex-wrap items-center gap-2">
+              <span class="rounded-full px-2.5 py-1 text-xs font-medium" :class="statusClass(task)">
+                {{ statusLabel(task) }}
+              </span>
+              <span v-if="task.category" class="text-sm text-gray-500">{{ task.category }}</span>
+            </div>
+            <h3 class="truncate text-lg font-semibold text-gray-900">{{ task.title }}</h3>
+            <p class="mt-1 text-sm text-gray-600">{{ task.description || '등록된 요청 사유가 없습니다.' }}</p>
+          </div>
+
+          <div class="grid grid-cols-2 gap-x-7 gap-y-2 text-sm sm:grid-cols-3 lg:shrink-0">
+            <div><p class="text-gray-500">요청 금액</p><p class="font-semibold">{{ formatAmount(task.requested_amount) }}</p></div>
+            <div><p class="text-gray-500">납부 기한</p><p class="font-semibold" :class="dueDateClass(task)">{{ formatDate(task.due_date) }}</p></div>
+            <div><p class="text-gray-500">남은 기간</p><p class="font-semibold" :class="dueDateClass(task)">{{ dueLabel(task) }}</p></div>
+          </div>
+
+          <button
+            v-if="canEditTask(task)"
+            type="button"
+            class="shrink-0 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            @click="openEditModal(task)"
+          >
+            요청 수정
+          </button>
+          <button
+            v-if="canProcessTask(task) && !task.is_request_confirmed"
+            type="button"
+            class="shrink-0 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+            @click="confirmTask(task)"
+          >
+            요청 확인
+          </button>
+          <button
+            v-else-if="canProcessTask(task) && task.status === 'PENDING_SETUP'"
+            type="button"
+            class="shrink-0 rounded-md bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700"
+            @click="openDueDateModal(task)"
+          >
+            기한 설정
+          </button>
+          <button
+            v-else-if="canProcessTask(task) && task.status !== 'COMPLETED'"
+            type="button"
+            class="shrink-0 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            @click="openCompleteModal(task)"
+          >
+            납부 완료 처리
+          </button>
+        </div>
+        <div v-if="task.status === 'COMPLETED'" class="mt-4 border-t pt-3 text-sm text-gray-600">
+          {{ formatDate(task.paid_at) }} 납부 · {{ formatAmount(task.paid_amount) }} · 증빙 {{ task.receipt_file_ids.length }}개
+        </div>
+        <div v-if="task.request_file_ids?.length" class="mt-4 border-t pt-3">
+          <button type="button" class="text-sm font-medium text-blue-700 hover:text-blue-900" @click="toggleRequestFiles(task)">
+            요청 첨부파일 {{ task.request_file_ids.length }}개 {{ taskFiles[task.id] ? '접기' : '펼치기' }}
+          </button>
+          <div v-if="taskFiles[task.id]" class="mt-2 flex flex-wrap gap-2">
+            <button
+              v-for="file in taskFiles[task.id]"
+              :key="file.id"
+              type="button"
+              class="rounded border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-100"
+              @click="downloadRequestFile(task, file)"
+            >
+              {{ file.file_name }}
+            </button>
+          </div>
+        </div>
+      </article>
+    </div>
+
+    <div v-if="selectedTask" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="closeModal">
+      <form class="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl" @submit.prevent="completeTask">
+        <h3 class="text-lg font-semibold text-gray-900">납부 완료 처리</h3>
+        <p class="mt-1 text-sm text-gray-500">{{ selectedTask.title }}</p>
+        <div class="mt-5 space-y-4">
+          <label class="block text-sm font-medium text-gray-700">실제 납부일
+            <input v-model="completionForm.paidAt" required type="date" class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2" />
+          </label>
+          <label class="block text-sm font-medium text-gray-700">실제 납부 금액
+            <input v-model.number="completionForm.paidAmount" required min="0" type="number" class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2" />
+          </label>
+          <div>
+            <p class="text-sm font-medium text-gray-700">납부확인증 <span class="text-red-500">*</span></p>
+            <div
+              class="mt-1 rounded-lg border-2 border-dashed p-5 text-center transition-colors"
+              :class="isReceiptDragOver ? 'border-blue-500 bg-blue-50' : 'border-gray-300 bg-gray-50'"
+              @dragenter.prevent="isReceiptDragOver = true"
+              @dragover.prevent="isReceiptDragOver = true"
+              @dragleave.prevent="isReceiptDragOver = false"
+              @drop.prevent="handleReceiptDrop"
+            >
+              <p class="text-sm text-gray-700">파일을 이곳으로 끌어다 놓거나 아래에서 선택하세요.</p>
+              <input required multiple type="file" class="mx-auto mt-3 block max-w-xs text-sm" @change="handleReceiptFiles" />
+              <p class="mt-2 text-xs text-gray-500">납부확인증, 이체확인증 등 증빙 파일을 첨부합니다.</p>
+            </div>
+            <p v-if="completionForm.receiptFiles.length" class="mt-2 text-xs text-gray-600">선택됨: {{ completionForm.receiptFiles.map(file => file.name).join(', ') }}</p>
+          </div>
+          <label class="block text-sm font-medium text-gray-700">메모
+            <textarea v-model="completionForm.note" rows="3" class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2" placeholder="거래번호나 참고사항을 입력하세요." />
+          </label>
+        </div>
+        <div class="mt-6 flex justify-end gap-3">
+          <button type="button" class="rounded-md bg-gray-100 px-4 py-2 text-sm text-gray-700 hover:bg-gray-200" @click="closeModal">취소</button>
+          <button type="submit" class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50" :disabled="completing">
+            {{ completing ? '처리 중...' : '완료 등록' }}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <div v-if="dueDateTask" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="closeDueDateModal">
+      <form class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl" @submit.prevent="setDueDate">
+        <h3 class="text-lg font-semibold text-gray-900">납부 기한 설정</h3>
+        <p class="mt-1 text-sm text-gray-500">{{ dueDateTask.title }}</p>
+        <label class="mt-5 block text-sm font-medium text-gray-700">실제 납부 기한
+          <input v-model="dueDateInput" required type="date" class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2" />
+        </label>
+        <div class="mt-6 flex justify-end gap-3">
+          <button type="button" class="rounded-md bg-gray-100 px-4 py-2 text-sm text-gray-700 hover:bg-gray-200" @click="closeDueDateModal">취소</button>
+          <button type="submit" class="rounded-md bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700 disabled:opacity-50" :disabled="settingDueDate">
+            {{ settingDueDate ? '저장 중...' : '기한 저장' }}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <div v-if="editingTask" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" @click.self="closeEditModal">
+      <form class="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg bg-white p-6 shadow-xl" @submit.prevent="updateTask">
+        <h3 class="text-lg font-semibold text-gray-900">납부 요청 수정</h3>
+        <p class="mt-1 text-sm text-gray-500">납부 담당자가 요청을 확인하기 전까지 수정할 수 있습니다.</p>
+        <div class="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <label class="text-sm font-medium text-gray-700">업무명<input v-model="editForm.name" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
+          <label class="text-sm font-medium text-gray-700">분류<input v-model="editForm.category" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
+          <label class="text-sm font-medium text-gray-700">요청 금액<input v-model="editForm.amount" min="0" type="number" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
+          <label class="text-sm font-medium text-gray-700">납부 기한<input v-model="editForm.dueDate" type="date" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
+          <label class="text-sm font-medium text-gray-700 sm:col-span-2">요청 사유<textarea v-model="editForm.description" rows="3" class="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" /></label>
+        </div>
+        <div class="mt-5">
+          <p class="text-sm font-medium text-gray-700">기존 첨부파일</p>
+          <div v-if="editFiles.length" class="mt-2 space-y-2">
+            <div v-for="file in editFiles" :key="file.id" class="flex items-center justify-between rounded border border-gray-200 px-3 py-2 text-sm">
+              <span>{{ file.file_name }}</span>
+              <button type="button" class="text-red-600 hover:text-red-800" @click="removeEditFile(file.id)">삭제</button>
+            </div>
+          </div>
+          <p v-else class="mt-2 text-sm text-gray-500">첨부파일이 없습니다.</p>
+        </div>
+        <div class="mt-4">
+          <p class="text-sm font-medium text-gray-700">추가 첨부파일</p>
+          <div class="mt-1 rounded-lg border-2 border-dashed p-4 text-center" :class="isEditDragOver ? 'border-blue-500 bg-blue-50' : 'border-gray-300 bg-gray-50'" @dragenter.prevent="isEditDragOver = true" @dragover.prevent="isEditDragOver = true" @dragleave.prevent="isEditDragOver = false" @drop.prevent="handleEditDrop">
+            <p class="text-sm text-gray-700">파일을 이곳으로 끌어다 놓거나 선택하세요.</p>
+            <input multiple type="file" class="mx-auto mt-2 block max-w-xs text-sm" @change="handleEditFiles" />
+          </div>
+          <p v-if="editForm.newFiles.length" class="mt-2 text-xs text-gray-600">추가됨: {{ editForm.newFiles.map(file => file.name).join(', ') }}</p>
+        </div>
+        <div class="mt-6 flex justify-end gap-3"><button type="button" class="rounded-md bg-gray-100 px-4 py-2 text-sm text-gray-700" @click="closeEditModal">취소</button><button type="submit" class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50" :disabled="updating">{{ updating ? '저장 중...' : '수정 저장' }}</button></div>
+      </form>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+import { useToast } from 'vue-toastification';
+import { paymentTaskApi } from '@/utils/approvalApi';
+import { useUserStore } from '@/stores/useUserStore';
+
+const emit = defineEmits(['summary-changed']);
+const toast = useToast();
+const userStore = useUserStore();
+const tasks = ref([]);
+const loading = ref(false);
+const completing = ref(false);
+const settingDueDate = ref(false);
+const selectedTask = ref(null);
+const dueDateTask = ref(null);
+const dueDateInput = ref('');
+const completionForm = ref({ paidAt: '', paidAmount: 0, note: '', receiptFiles: [] });
+const isReceiptDragOver = ref(false);
+const isEditDragOver = ref(false);
+const taskFiles = ref({});
+const selectedFilter = ref('ALL');
+const editingTask = ref(null);
+const updating = ref(false);
+const editFiles = ref([]);
+const editForm = ref({ name: '', category: '', amount: '', dueDate: '', description: '', newFiles: [], deletedFileIds: [] });
+
+const today = () => new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' });
+const dateDiff = dueDate => dueDate
+  ? Math.ceil((new Date(`${dueDate}T00:00:00`) - new Date(`${today()}T00:00:00`)) / 86400000)
+  : null;
+const isOpenTask = task => task.status !== 'COMPLETED';
+const todayTasks = computed(() => tasks.value.filter(task => isOpenTask(task) && dateDiff(task.due_date) === 0));
+const soonTasks = computed(() => tasks.value.filter(task => isOpenTask(task) && dateDiff(task.due_date) >= 1 && dateDiff(task.due_date) <= 3));
+const filters = computed(() => [
+  { id: 'SOON', label: '3일 이내 마감', count: soonTasks.value.length, activeClass: 'border-amber-300 bg-amber-50 text-amber-800' },
+  { id: 'TODAY', label: '당일 마감', count: todayTasks.value.length, activeClass: 'border-blue-300 bg-blue-50 text-blue-800' },
+  { id: 'ALL', label: '전체 업무', count: tasks.value.length, activeClass: 'border-gray-400 bg-gray-100 text-gray-900' },
+]);
+const filteredTasks = computed(() => selectedFilter.value === 'TODAY'
+  ? todayTasks.value
+  : selectedFilter.value === 'SOON' ? soonTasks.value : tasks.value);
+
+const loadTasks = async () => {
+  loading.value = true;
+  try {
+    tasks.value = await paymentTaskApi.getMyTasks();
+  } catch (error) {
+    toast.error(error.message || '납부 업무를 불러오지 못했습니다.');
+  } finally {
+    loading.value = false;
+  }
+};
+
+const refreshSummary = async () => {
+  try {
+    emit('summary-changed', await paymentTaskApi.getSummary());
+  } catch (error) {
+    // 목록 조회와 무관한 보조 정보이므로 실패해도 화면을 막지 않는다.
+  }
+};
+
+const formatAmount = value => value === null || value === undefined ? '-' : `${Number(value).toLocaleString('ko-KR')}원`;
+const formatDate = value => value ? new Intl.DateTimeFormat('ko-KR', { dateStyle: 'medium' }).format(new Date(`${value}T00:00:00`)) : '-';
+const statusLabel = task => ({ COMPLETED: '납부 완료', PENDING_PAYMENT: '납부 대기', PENDING_SETUP: '기한 설정 필요' })[task.status] || '납부 대기';
+const statusClass = task => task.status === 'COMPLETED' ? 'bg-green-100 text-green-700' : task.status === 'PENDING_SETUP' ? 'bg-slate-100 text-slate-700' : 'bg-amber-100 text-amber-700';
+const dueDateClass = task => dateDiff(task.due_date) !== null && dateDiff(task.due_date) >= 0 && dateDiff(task.due_date) <= 3 && task.status !== 'COMPLETED' ? 'text-amber-700' : 'text-gray-900';
+const dueLabel = task => {
+  if (task.status === 'COMPLETED') return '완료';
+  if (!task.due_date) return '미설정';
+  const diff = dateDiff(task.due_date);
+  return diff < 0 ? '-' : diff === 0 ? 'D-day' : `D-${diff}`;
+};
+const canProcessTask = task => task.assignee_id === (userStore.currentUser?.user_id || userStore.currentUser?.id);
+const canEditTask = task => task.requester_id === (userStore.currentUser?.user_id || userStore.currentUser?.id) && !task.is_request_confirmed && task.status !== 'COMPLETED';
+
+const openCompleteModal = task => {
+  selectedTask.value = task;
+  completionForm.value = { paidAt: today(), paidAmount: task.requested_amount, note: '', receiptFiles: [] };
+};
+const closeModal = () => { selectedTask.value = null; };
+const openDueDateModal = task => {
+  dueDateTask.value = task;
+  dueDateInput.value = task.due_date || today();
+};
+const closeDueDateModal = () => { dueDateTask.value = null; };
+const openEditModal = async task => {
+  editingTask.value = task;
+  editForm.value = {
+    name: task.request_name || '',
+    category: task.category || '',
+    amount: task.requested_amount ?? '',
+    dueDate: task.due_date || '',
+    description: task.description || '',
+    newFiles: [],
+    deletedFileIds: [],
+  };
+  try {
+    editFiles.value = await paymentTaskApi.getTaskFiles(task.id);
+  } catch (error) {
+    editFiles.value = [];
+    toast.error('기존 첨부파일을 불러오지 못했습니다.');
+  }
+};
+const closeEditModal = () => { editingTask.value = null; };
+const handleEditFiles = event => { editForm.value.newFiles = Array.from(event.target.files || []); };
+const handleEditDrop = event => {
+  isEditDragOver.value = false;
+  editForm.value.newFiles = Array.from(event.dataTransfer.files || []);
+};
+const removeEditFile = fileId => {
+  editForm.value.deletedFileIds.push(fileId);
+  editFiles.value = editFiles.value.filter(file => file.id !== fileId);
+};
+const updateTask = async () => {
+  updating.value = true;
+  try {
+    await paymentTaskApi.updateTask(editingTask.value.id, {
+      name: editForm.value.name,
+      category: editForm.value.category,
+      amount: editForm.value.amount === '' ? undefined : Number(editForm.value.amount),
+      due_date: editForm.value.dueDate,
+      description: editForm.value.description,
+      files: editForm.value.newFiles,
+      deletedFileIds: editForm.value.deletedFileIds,
+    });
+    toast.success('납부 요청을 수정했습니다.');
+    closeEditModal();
+    await loadTasks();
+  } catch (error) {
+    toast.error(error.message || '납부 요청 수정에 실패했습니다.');
+  } finally {
+    updating.value = false;
+  }
+};
+const confirmTask = async task => {
+  if (!confirm('요청 내용을 확인하면 요청자는 더 이상 수정할 수 없습니다. 계속하시겠습니까?')) return;
+  try {
+    await paymentTaskApi.confirmTask(task.id);
+    toast.success('요청을 확인했습니다.');
+    await loadTasks();
+    await refreshSummary();
+  } catch (error) {
+    toast.error(error.message || '요청 확인에 실패했습니다.');
+  }
+};
+const toggleRequestFiles = async task => {
+  if (taskFiles.value[task.id]) {
+    const nextFiles = { ...taskFiles.value };
+    delete nextFiles[task.id];
+    taskFiles.value = nextFiles;
+    return;
+  }
+  try {
+    taskFiles.value = { ...taskFiles.value, [task.id]: await paymentTaskApi.getTaskFiles(task.id) };
+  } catch (error) {
+    toast.error(error.message || '요청 첨부파일을 불러오지 못했습니다.');
+  }
+};
+const downloadRequestFile = async (task, file) => {
+  if (!file.id) {
+    toast.error('첨부파일 정보를 찾을 수 없습니다.');
+    return;
+  }
+  try {
+    await paymentTaskApi.downloadTaskFile(task.id, file.id, file.file_name);
+  } catch (error) {
+    toast.error(error.message || '첨부파일 다운로드에 실패했습니다.');
+  }
+};
+const handleReceiptFiles = event => { completionForm.value.receiptFiles = Array.from(event.target.files || []); };
+const handleReceiptDrop = event => {
+  isReceiptDragOver.value = false;
+  completionForm.value.receiptFiles = Array.from(event.dataTransfer.files || []);
+};
+const completeTask = async () => {
+  if (!completionForm.value.receiptFiles.length) {
+    toast.warning('납부확인증을 첨부해주세요.');
+    return;
+  }
+  completing.value = true;
+  try {
+    await paymentTaskApi.completeTask(selectedTask.value.id, completionForm.value);
+    toast.success('납부 완료와 증빙이 등록되었습니다.');
+    closeModal();
+    await loadTasks();
+    await refreshSummary();
+  } catch (error) {
+    toast.error(error.message || '납부 완료 처리에 실패했습니다.');
+  } finally {
+    completing.value = false;
+  }
+};
+
+const setDueDate = async () => {
+  settingDueDate.value = true;
+  try {
+    await paymentTaskApi.setDueDate(dueDateTask.value.id, dueDateInput.value);
+    toast.success('납부 기한을 설정했습니다.');
+    closeDueDateModal();
+    await loadTasks();
+    await refreshSummary();
+  } catch (error) {
+    toast.error(error.message || '납부 기한 설정에 실패했습니다.');
+  } finally {
+    settingDueDate.value = false;
+  }
+};
+
+onMounted(async () => {
+  if (!userStore.currentUser) await userStore.fetchCurrentUser();
+  await loadTasks();
+  await refreshSummary();
+});
+</script>

--- a/src/stores/useApprovalNotificationStore.js
+++ b/src/stores/useApprovalNotificationStore.js
@@ -148,6 +148,19 @@ export const useApprovalNotificationStore = defineStore('approvalNotification', 
         };
         notifications.value.unshift(completedNotification);
         break;
+
+      case 'payment_task_assigned':
+        const paymentTaskNotification = {
+          id: Date.now(),
+          type: 'payment_task',
+          title: '새로운 납부 업무',
+          message: `${data.data.title}${data.data.due_date ? ` · 기한 ${data.data.due_date}` : ' · 기한 설정 필요'}`,
+          timestamp: new Date(),
+          data: data.data
+        };
+        notifications.value.unshift(paymentTaskNotification);
+        showBrowserNotification(paymentTaskNotification);
+        break;
         
       case 'approval_rejected':
         // 결재 반려 알림

--- a/src/utils/approvalApi.js
+++ b/src/utils/approvalApi.js
@@ -220,6 +220,24 @@ export const paymentTaskApi = {
     return response.json();
   },
 
+  async updateCompletion(taskId, { paidAt, paidAmount, note, receiptFiles, deletedFileIds }) {
+    const formData = new FormData();
+    formData.append('paid_at', paidAt);
+    formData.append('paid_amount', paidAmount === null || paidAmount === undefined ? '' : String(paidAmount));
+    formData.append('note', note);
+    if (deletedFileIds.length) {
+      formData.append('deleted_file_ids', JSON.stringify(deletedFileIds));
+    }
+    receiptFiles.forEach(file => formData.append('receipt_files', file));
+
+    const response = await authFetch(`${PAYMENT_TASK_API_URL}/${taskId}/completion`, {
+      method: 'PATCH',
+      body: formData,
+    });
+    await handleApiError(response);
+    return response.json();
+  },
+
   async getTaskFiles(taskId) {
     const response = await authFetch(`${PAYMENT_TASK_API_URL}/${taskId}/files`);
     await handleApiError(response);
@@ -243,7 +261,9 @@ export const paymentTaskApi = {
   async completeTask(taskId, { paidAt, paidAmount, note, receiptFiles }) {
     const formData = new FormData();
     formData.append('paid_at', paidAt);
-    formData.append('paid_amount', String(paidAmount));
+    if (paidAmount !== null && paidAmount !== undefined && paidAmount !== '') {
+      formData.append('paid_amount', String(paidAmount));
+    }
     if (note) formData.append('note', note);
     receiptFiles.forEach(file => formData.append('receipt_files', file));
 

--- a/src/utils/approvalApi.js
+++ b/src/utils/approvalApi.js
@@ -3,6 +3,9 @@ import { authFetch } from '@/utils/authFetch';
 
 const FILE_API_URL = import.meta.env.VITE_FILE_API_URL;
 const API_URL = import.meta.env.VITE_API_URL;
+const APPROVAL_API_URL = import.meta.env.VITE_APPROVAL_API_URL;
+const PAYMENT_TASK_API_URL = import.meta.env.VITE_PAYMENT_TASK_API_URL ||
+  `${APPROVAL_API_URL.replace(/\/approvals\/?$/, '')}/payment-tasks`;
 
 // API 에러 처리 래퍼
 const handleApiError = async (response) => {
@@ -143,6 +146,113 @@ export const approvalLineApi = {
     }
     
     return await response.json();
+  },
+};
+
+// 결재 승인 뒤 실제 납부를 처리하는 후속 업무 API
+export const paymentTaskApi = {
+  async createTask(taskData) {
+    const formData = new FormData();
+    formData.append('assignee_id', taskData.assignee_id);
+    ['name', 'category', 'amount', 'due_date', 'description'].forEach(key => {
+      if (taskData[key] !== null && taskData[key] !== undefined && taskData[key] !== '') {
+        formData.append(key, String(taskData[key]));
+      }
+    });
+    taskData.files.forEach(file => formData.append('files', file));
+
+    const response = await authFetch(PAYMENT_TASK_API_URL, {
+      method: 'POST',
+      body: formData,
+    });
+    await handleApiError(response);
+    return response.json();
+  },
+
+  async getMyTasks(status) {
+    const query = status ? `?status=${encodeURIComponent(status)}` : '';
+    const response = await authFetch(`${PAYMENT_TASK_API_URL}/my${query}`);
+    await handleApiError(response);
+    return response.json();
+  },
+
+  async getSummary() {
+    const response = await authFetch(`${PAYMENT_TASK_API_URL}/summary`);
+    await handleApiError(response);
+    return response.json();
+  },
+
+  async setDueDate(taskId, dueDate) {
+    const response = await authFetch(`${PAYMENT_TASK_API_URL}/${taskId}/due-date`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ due_date: dueDate }),
+    });
+    await handleApiError(response);
+    return response.json();
+  },
+
+  async confirmTask(taskId) {
+    const response = await authFetch(`${PAYMENT_TASK_API_URL}/${taskId}/confirm`, {
+      method: 'POST',
+    });
+    await handleApiError(response);
+    return response.json();
+  },
+
+  async updateTask(taskId, taskData) {
+    const formData = new FormData();
+    ['assignee_id', 'name', 'category', 'amount', 'due_date', 'description'].forEach(key => {
+      if (taskData[key] !== undefined && taskData[key] !== null) {
+        formData.append(key, String(taskData[key]));
+      }
+    });
+    if (taskData.deletedFileIds?.length) {
+      formData.append('deleted_file_ids', JSON.stringify(taskData.deletedFileIds));
+    }
+    taskData.files?.forEach(file => formData.append('files', file));
+
+    const response = await authFetch(`${PAYMENT_TASK_API_URL}/${taskId}`, {
+      method: 'PATCH',
+      body: formData,
+    });
+    await handleApiError(response);
+    return response.json();
+  },
+
+  async getTaskFiles(taskId) {
+    const response = await authFetch(`${PAYMENT_TASK_API_URL}/${taskId}/files`);
+    await handleApiError(response);
+    return (await response.json()).map(file => ({ ...file, id: file.id || file._id }));
+  },
+
+  async downloadTaskFile(taskId, fileId, fileName) {
+    const response = await authFetch(`${PAYMENT_TASK_API_URL}/${taskId}/files/${fileId}/download`);
+    await handleApiError(response);
+    const blob = await response.blob();
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = fileName;
+    document.body.appendChild(anchor);
+    anchor.click();
+    window.URL.revokeObjectURL(url);
+    document.body.removeChild(anchor);
+  },
+
+  async completeTask(taskId, { paidAt, paidAmount, note, receiptFiles }) {
+    const formData = new FormData();
+    formData.append('paid_at', paidAt);
+    formData.append('paid_amount', String(paidAmount));
+    if (note) formData.append('note', note);
+    receiptFiles.forEach(file => formData.append('receipt_files', file));
+
+    const response = await authFetch(`${PAYMENT_TASK_API_URL}/${taskId}/complete`, {
+      method: 'POST',
+      body: formData,
+    });
+    await handleApiError(response);
+    return response.json();
   },
 };
 


### PR DESCRIPTION
## 변경 내용

전자결재 납부 업무 기능을 개선했습니다.

- 납부 업무를 카드형 목록으로 변경
- 요청 받은 업무와 내가 요청한 업무 탭 분리
- 마감 임박, 당일 마감, 납부 완료 필터 추가
- 완료된 업무를 목록 뒤로 정렬
- 납부 완료 후 실제 납부일, 금액, 메모, 증빙파일 수정 가능
- 실제 납부 금액 및 납부확인증을 선택사항으로 변경
- 증빙파일 업로드 화면을 기존 전자결재 첨부 방식과 통일
- 첨부파일 목록 내부 스크롤 적용
- 금액 입력 시 천 단위 쉼표 표시
- 파일 드래그 중 모달이 닫히는 문제 수정

## 백엔드 변경

- 완료된 납부 결과 수정 API 추가
- 납부 담당자만 완료 후 납부 결과와 증빙을 수정하도록 권한 분리

## 확인 사항

- 프런트 `pnpm build` 통과
- 백엔드 Python 문법 검사 통과