### PR TITLE
납부 업무 딥링크 추가

### DIFF
--- a/src/components/approval/ApprovalMain.vue
+++ b/src/components/approval/ApprovalMain.vue
@@ -122,7 +122,7 @@
         </div>
 
         <div v-if="activeTab === 'payment-tasks'">
-          <PaymentTaskList @summary-changed="handlePaymentTaskSummary" />
+          <PaymentTaskList :highlighted-task-id="highlightedTaskId" @summary-changed="handlePaymentTaskSummary" />
         </div>
 
         <!-- 전체 검색 -->
@@ -163,8 +163,8 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
+import { ref, computed, onMounted, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import { Plus } from 'lucide-vue-next';
 import { useUserStore } from '@/stores/useUserStore';
 import { useApprovalStore } from '@/stores/useApprovalStore';
@@ -181,6 +181,7 @@ import PaymentTaskList from './PaymentTaskList.vue';
 import { paymentTaskApi } from '@/utils/approvalApi';
 
 const router = useRouter();
+const route = useRoute();
 const userStore = useUserStore();
 const approvalStore = useApprovalStore();
 const approvalNotificationStore = useApprovalNotificationStore();
@@ -191,6 +192,7 @@ const showDetailModal = ref(false);
 const selectedApproval = ref(null);
 const editRequestId = ref(null);
 const paymentTaskSummary = ref({ today_count: 0, confirmation_count: 0 });
+const highlightedTaskId = computed(() => route.params.taskId || null);
 
 // 새 결재 생성 탭으로 이동
 const goToCreateApproval = () => {
@@ -229,6 +231,10 @@ onMounted(async () => {
     console.error('초기 데이터 로드 오류:', error);
   }
 });
+
+watch(highlightedTaskId, taskId => {
+  if (taskId) activeTab.value = 'payment-tasks';
+}, { immediate: true });
 
 const refreshPaymentTaskSummary = async () => {
   try {

--- a/src/components/approval/PaymentTaskList.vue
+++ b/src/components/approval/PaymentTaskList.vue
@@ -44,7 +44,13 @@
       조건에 맞는 납부 업무가 없습니다.
     </div>
     <div v-else class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-      <article v-for="task in filteredTasks" :key="task.id" class="flex min-w-0 flex-col rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md">
+      <article
+        v-for="task in filteredTasks"
+        :key="task.id"
+        :ref="element => setTaskElement(task.id, element)"
+        class="flex min-w-0 flex-col rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+        :class="task.id === highlightedTaskId ? 'border-2 border-blue-500 ring-4 ring-blue-100' : ''"
+      >
         <div class="min-w-0">
           <div class="mb-2 flex flex-wrap items-center gap-2">
             <span class="rounded-full px-2.5 py-1 text-xs font-medium" :class="statusClass(task)">
@@ -279,16 +285,20 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onMounted, ref } from 'vue';
+import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { File, FileText, Upload, X } from 'lucide-vue-next';
 import { useToast } from 'vue-toastification';
 import { paymentTaskApi } from '@/utils/approvalApi';
 import { useUserStore } from '@/stores/useUserStore';
 
+const props = defineProps({
+  highlightedTaskId: { type: String, default: null },
+});
 const emit = defineEmits(['summary-changed']);
 const toast = useToast();
 const userStore = useUserStore();
 const tasks = ref([]);
+const taskElements = new Map();
 const loading = ref(false);
 const completing = ref(false);
 const settingDueDate = ref(false);
@@ -337,6 +347,30 @@ const filteredTasks = computed(() => {
   if (selectedFilter.value === 'COMPLETED') return completedTasks.value;
   return scopedTasks.value;
 });
+
+const highlightedTaskId = computed(() => props.highlightedTaskId);
+const setTaskElement = (taskId, element) => {
+  if (element) taskElements.set(taskId, element);
+  else taskElements.delete(taskId);
+};
+
+const showHighlightedTask = async () => {
+  const taskId = highlightedTaskId.value;
+  if (!taskId) return;
+
+  try {
+    const task = await paymentTaskApi.getTask(taskId);
+    const index = tasks.value.findIndex(item => item.id === task.id);
+    if (index >= 0) tasks.value[index] = task;
+    else tasks.value = [task, ...tasks.value];
+    selectedScope.value = task.assignee_id === currentUserId.value ? 'ASSIGNED' : 'REQUESTED';
+    selectedFilter.value = 'ALL';
+    await nextTick();
+    taskElements.get(task.id)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  } catch (error) {
+    toast.error(error.message || '이 납부 업무를 열 수 없습니다.');
+  }
+};
 
 const loadTasks = async () => {
   loading.value = true;
@@ -604,6 +638,9 @@ const setDueDate = async () => {
 onMounted(async () => {
   if (!userStore.currentUser) await userStore.fetchCurrentUser();
   await loadTasks();
+  await showHighlightedTask();
   await refreshSummary();
 });
+
+watch(highlightedTaskId, showHighlightedTask);
 </script>

--- a/src/components/login/Login.vue
+++ b/src/components/login/Login.vue
@@ -34,7 +34,8 @@ async function login() {
 
   if (response.ok) {
     localStorage.setItem('access_token', data.access_token);
-    router.push('/');
+    const redirect = router.currentRoute.value.query.redirect;
+    router.push(typeof redirect === 'string' && redirect.startsWith('/') ? redirect : '/');
     return;
   }
 

--- a/src/router.js
+++ b/src/router.js
@@ -15,6 +15,11 @@ const routes = [
   { path: '/', component: HomeView, meta: { requiresAuth: true } },
   { path: '/extra', component: ExtraView, meta: { requiresAuth: true } },
   { path: '/approval', component: ApprovalView, meta: { requiresAuth: true } },
+  {
+    path: '/approval/payment-tasks/:taskId',
+    component: ApprovalView,
+    meta: { requiresAuth: true },
+  },
   { path: '/user-approval', component: UserApprovalView, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/wiki', component: WikiApp, meta: { requiresAuth: true } },
   { path: '/login', component: LoginView },
@@ -55,17 +60,17 @@ router.beforeEach(async (to) => {
             credentials: 'include', // 쿠키 전송
           });
           // refresh도 실패 → 로그인 페이지로
-          return '/login';
+          return { path: '/login', query: { redirect: to.fullPath } };
         }
       }
     } catch (err) {
       console.error('토큰 에러:', err);
-      return '/login';
+      return { path: '/login', query: { redirect: to.fullPath } };
     }
   }
 
   if (to.meta.requiresAuth && !isAuthenticated) {
-    return '/login';
+    return { path: '/login', query: { redirect: to.fullPath } };
   }
 
   if (to.path === '/' && !(roles.includes('VOUCHER') || roles.includes('ADMIN'))) {

--- a/src/utils/approvalApi.js
+++ b/src/utils/approvalApi.js
@@ -151,6 +151,12 @@ export const approvalLineApi = {
 
 // 결재 승인 뒤 실제 납부를 처리하는 후속 업무 API
 export const paymentTaskApi = {
+  async getTask(taskId) {
+    const response = await authFetch(`${PAYMENT_TASK_API_URL}/${taskId}`);
+    await handleApiError(response);
+    return response.json();
+  },
+
   async createTask(taskData) {
     const formData = new FormData();
     formData.append('assignee_id', taskData.assignee_id);


### PR DESCRIPTION
## 변경 내용

- 납부 업무 딥링크 경로를 추가하고, 대상 업무 카드를 열어 강조합니다.
- 로그인이 필요한 경우 로그인 뒤 원래 납부 업무로 돌아갑니다.
- 권한이 확인된 납부 업무 단건 조회 API를 호출하도록 연결했습니다.

## 변경 이유

노션 캘린더의 `DUP에서 확인` 링크가 민감한 정보를 외부에 노출하지 않으면서 정확한 납부 업무를 열어야 합니다.

## 확인

- `pnpm build` 성공
